### PR TITLE
Closes #10: Implement disable metatile generation options

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ Branches that address a filed issue should fall into one of the above categories
 E.g. if Issue #12 reports a bug, the branch to fix this could be called `bugfix/issue-0012`. If Issue #27 requests a
 feature, the branch to implement this could be called `feature/issue-0027`. If necessary, the title may be extended for
 more specificity. E.g. if `issue-0027` contains both a reported bug and a related feature request, we may have a
-`bugfix/issue-0027-broken-attr` as well as a `feature/issue-0027-generate-attrs`.
+`bugfix/issue-0027/broken-attr` as well as a `feature/issue-0027/generate-attrs`.
 
 ## Branch Cleanup
 Please use `git rebase --interactive` to clean up your branch before submitting a PR. If you have a ton of commits with

--- a/include/cli_options.h
+++ b/include/cli_options.h
@@ -61,6 +61,20 @@ const std::string TILES_OUTPUT_PAL_DESC =
 "             the final in-game tiles. Default value is `greyscale'.\n";
 constexpr int TILES_OUTPUT_PAL_VAL = 1001;
 
+const std::string DISABLE_METATILE_GENERATION = "disable-metatile-generation";
+const std::string DISABLE_METATILE_GENERATION_DESC =
+"        -" + DISABLE_METATILE_GENERATION + "\n"
+"             Disable generation of `metatiles.bin'. Only enable this if you want to manage\n"
+"             metatiles manually via Porymap.\n";
+constexpr int DISABLE_METATILE_GENERATION_VAL = 1002;
+
+const std::string DISABLE_ATTRIBUTE_GENERATION = "disable-attribute-generation";
+const std::string DISABLE_ATTRIBUTE_GENERATION_DESC =
+"        -" + DISABLE_ATTRIBUTE_GENERATION + "\n"
+"             Disable generation of `metatile_attributes.bin'. Only enable this if you want to\n"
+"             manage metatile attributes manually via Porymap.\n";
+constexpr int DISABLE_ATTRIBUTE_GENERATION_VAL = 1003;
+
 
 // Tileset generation options
 

--- a/include/types.h
+++ b/include/types.h
@@ -824,9 +824,15 @@ struct DecompilerSourcePaths {
 
 struct Output {
   TilesOutputPalette paletteMode;
+  bool disableMetatileGeneration;
+  bool disableAttributeGeneration;
   std::string path;
 
-  Output() : paletteMode{TilesOutputPalette::GREYSCALE}, path{} {}
+  Output()
+      : paletteMode{TilesOutputPalette::GREYSCALE}, disableMetatileGeneration{false}, disableAttributeGeneration{false},
+        path{}
+  {
+  }
 };
 
 struct CompilerConfig {

--- a/src/cli_parser.cpp
+++ b/src/cli_parser.cpp
@@ -341,6 +341,8 @@ const std::string COMPILE_HELP =
 "    Driver Options\n" +
 OUTPUT_DESC + "\n" +
 TILES_OUTPUT_PAL_DESC + "\n" +
+DISABLE_METATILE_GENERATION_DESC + "\n" +
+DISABLE_ATTRIBUTE_GENERATION_DESC + "\n" +
 "    Tileset Compilation & Decompilation Options\n" +
 TARGET_BASE_GAME_DESC + "\n" +
 DUAL_LAYER_DESC + "\n" +
@@ -390,6 +392,8 @@ static void parseSubcommandOptions(PtContext &ctx, int argc, char *const *argv)
       {OUTPUT.c_str(), required_argument, nullptr, OUTPUT_VAL},
       {OUTPUT_SHORT.c_str(), required_argument, nullptr, OUTPUT_VAL},
       {TILES_OUTPUT_PAL.c_str(), required_argument, nullptr, TILES_OUTPUT_PAL_VAL},
+      {DISABLE_METATILE_GENERATION.c_str(), no_argument, nullptr, DISABLE_METATILE_GENERATION_VAL},
+      {DISABLE_ATTRIBUTE_GENERATION.c_str(), no_argument, nullptr, DISABLE_ATTRIBUTE_GENERATION_VAL},
 
       // Tileset generation options
       {TARGET_BASE_GAME.c_str(), required_argument, nullptr, TARGET_BASE_GAME_VAL},
@@ -535,6 +539,12 @@ static void parseSubcommandOptions(PtContext &ctx, int argc, char *const *argv)
       break;
     case TILES_OUTPUT_PAL_VAL:
       ctx.output.paletteMode = parseTilesPngPaletteMode(ctx.err, TILES_OUTPUT_PAL, optarg);
+      break;
+    case DISABLE_METATILE_GENERATION_VAL:
+      ctx.output.disableMetatileGeneration = true;
+      break;
+    case DISABLE_ATTRIBUTE_GENERATION_VAL:
+      ctx.output.disableAttributeGeneration = true;
       break;
 
     // Tileset compilation & decompilation options

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -853,13 +853,17 @@ static void driveCompile(PtContext &ctx)
   emitCompiledAnims(ctx, (ctx.compilerContext.resultTileset)->anims, (ctx.compilerContext.resultTileset)->palettes,
                     animsPath);
 
-  std::ofstream outMetatiles{metatilesPath.string()};
-  emitMetatilesBin(ctx, outMetatiles, *(ctx.compilerContext.resultTileset));
-  outMetatiles.close();
+  if (!ctx.output.disableMetatileGeneration) {
+    std::ofstream outMetatiles{metatilesPath.string()};
+    emitMetatilesBin(ctx, outMetatiles, *(ctx.compilerContext.resultTileset));
+    outMetatiles.close();
+  }
 
-  std::ofstream outAttributes{attributesPath.string()};
-  emitAttributes(ctx, outAttributes, behaviorReverseMap, *(ctx.compilerContext.resultTileset));
-  outAttributes.close();
+  if (!ctx.output.disableAttributeGeneration) {
+    std::ofstream outAttributes{attributesPath.string()};
+    emitAttributes(ctx, outAttributes, behaviorReverseMap, *(ctx.compilerContext.resultTileset));
+    outAttributes.close();
+  }
 }
 
 void drive(PtContext &ctx)


### PR DESCRIPTION
Closes #10. User can now optionally supply `-disable-metatile-generation` to skip generation of `metatiles.bin`. User can supply `-disable-attribute-generation` to skip generation of `metatile_attributes.bin`. Most users won't need these. But some users may want to manage these files manually via Porymap.