### PR TITLE
Fix "Image height is zero" error when secondary tileset has zero unique tiles

### DIFF
--- a/Porytiles-1.x/lib/src/compiler.cpp
+++ b/Porytiles-1.x/lib/src/compiler.cpp
@@ -808,9 +808,9 @@ std::unique_ptr<CompiledTileset> compile(PorytilesContext &ctx, CompilerMode com
   }
 
   /*
-   * Push back transparent tiles to pad out tileset to multiple of 16
+   * Push back transparent tiles to pad out tileset to a non-zero multiple of 16
    */
-  while (compiled->tiles.size() % 16 != 0) {
+  while (compiled->tiles.size() % 16 != 0 || compiled->tiles.size() == 0) {
     compiled->tiles.push_back(GBA_TILE_TRANSPARENT);
     compiled->paletteIndexesOfTile.push_back(0);
   }


### PR DESCRIPTION
The easiest way to trigger this is to create a secondary tileset using the same top/middle/bottom images for both the primary and secondary tileset. Since the primary and secondary all use the same tiles, the secondary will have zero unique tiles.

Formerly, when porytiles would write a image representing zero tiles, porytiles would attempt to *write* a zero-height image, with an emphasis on "not read a zero-height image", which libpng would call out as an error and would cause compilation to fail.

With this change, the output image for a tileset with zero tiles will be padded with transparent tiles, to create an output image with a non-zero height that libpng will be willing to write.
