### PR TITLE
Resolved confusing behavior that could happen when issuing `-Wtransparency-collapse`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,43 +9,58 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `decompile-secondary` command to decompile secondary tilesets ([#17](https://github.com/grunt-lucas/porytiles/pull/17))
+- `decompile-secondary` command to decompile secondary
+  tilesets ([#17](https://github.com/grunt-lucas/porytiles/pull/17))
 
-- `-normalize-transparency` option for the decompile commands ([37668ac](https://github.com/grunt-lucas/porytiles/commit/37668ac))([b710078](https://github.com/grunt-lucas/porytiles/commit/b710078))
+- `-normalize-transparency` option for the decompile
+  commands ([37668ac](https://github.com/grunt-lucas/porytiles/commit/37668ac))([b710078](https://github.com/grunt-lucas/porytiles/commit/b710078))
 
-- `-Wtile-index-out-of-range` for use with the decompile commands ([#18](https://github.com/grunt-lucas/porytiles/pull/18))
+- `-Wtile-index-out-of-range` for use with the decompile
+  commands ([#18](https://github.com/grunt-lucas/porytiles/pull/18))
 
-- `-Wpalette-index-out-of-range` for use with the decompile commands ([#18](https://github.com/grunt-lucas/porytiles/pull/18))
+- `-Wpalette-index-out-of-range` for use with the decompile
+  commands ([#18](https://github.com/grunt-lucas/porytiles/pull/18))
 
-- Options to disable generation of `metatiles.bin` and `metatile_attributes.bin` ([#16](https://github.com/grunt-lucas/porytiles/pull/16))
-  - `-disable-metatile-generation` and `-disable-attribute-generation`
+- Options to disable generation of `metatiles.bin` and
+  `metatile_attributes.bin` ([#16](https://github.com/grunt-lucas/porytiles/pull/16))
+    - `-disable-metatile-generation` and `-disable-attribute-generation`
 
-- Added support for `-best-branches=smart` pal assignment mode, which prunes `populated + 1` number of branches per vertex ([#18](https://github.com/grunt-lucas/porytiles/pull/18))
-  - assign config search matrix now tries smart prune before trying a constant prune
+- Added support for `-best-branches=smart` pal assignment mode, which prunes `populated + 1` number of branches per
+  vertex ([#18](https://github.com/grunt-lucas/porytiles/pull/18))
+    - assign config search matrix now tries smart prune before trying a constant prune
 
-- `-Wkey-frame-missing-colors` flags cases where user might run into [Issue #60](https://github.com/grunt-lucas/porytiles/issues/60) ([#85](https://github.com/grunt-lucas/porytiles/pull/85))
+- `-Wkey-frame-missing-colors` flags cases where user might run
+  into [Issue #60](https://github.com/grunt-lucas/porytiles/issues/60) ([#85](https://github.com/grunt-lucas/porytiles/pull/85))
 
 - Added palette primer feature
-  - https://github.com/grunt-lucas/porytiles/commit/594795b
-  - https://github.com/grunt-lucas/porytiles/commit/7b43e0d
-  - https://github.com/grunt-lucas/porytiles/commit/d3af999
-  - https://github.com/grunt-lucas/porytiles/commit/7681651
-  - [#89](https://github.com/grunt-lucas/porytiles/pull/89)
+    - https://github.com/grunt-lucas/porytiles/commit/594795b
+    - https://github.com/grunt-lucas/porytiles/commit/7b43e0d
+    - https://github.com/grunt-lucas/porytiles/commit/d3af999
+    - https://github.com/grunt-lucas/porytiles/commit/7681651
+    - [#89](https://github.com/grunt-lucas/porytiles/pull/89)
 
 ### Changed
 
-- Fixed bug from issue [Secondary tileset attributes aren't generated #1](https://github.com/grunt-lucas/porytiles/issues/1)
+- Fixed bug from
+  issue [Secondary tileset attributes aren't generated #1](https://github.com/grunt-lucas/porytiles/issues/1)
 
 - `-Wkey-frame-missing-assignment` now called `-Wkey-frame-no-matching-tile`
 
-- Subcommand help menus are much more refined, they now only show info relevant to the given subcommand ([#51](https://github.com/grunt-lucas/porytiles/pull/51))
+- Subcommand help menus are much more refined, they now only show info relevant to the given
+  subcommand ([#51](https://github.com/grunt-lucas/porytiles/pull/51))
 
 - Build system overhaul, now using CMake ([#62](https://github.com/grunt-lucas/porytiles/pull/62))
 
-- Fixed an IHDR "image height is zero" error when secondary tileset is empty, thanks @rayrobdad ([#72](https://github.com/grunt-lucas/porytiles/pull/72))
+- Fixed an IHDR "image height is zero" error when secondary tileset is empty, thanks
+  @rayrobdad ([#72](https://github.com/grunt-lucas/porytiles/pull/72))
 
 - `assign.cfg` now called `assign.cache`
-  - https://github.com/grunt-lucas/porytiles/commit/1e4b484efd1e02e1e9856a412196ea3ac662716e
+    - https://github.com/grunt-lucas/porytiles/commit/1e4b484efd1e02e1e9856a412196ea3ac662716e
+
+- Some QoL improvements around `-Wtransparency-collapse`:
+  fixed a false warning case and changed behavior so transparent is inserted when warning is triggered
+    - PRs: [#122](https://github.com/grunt-lucas/porytiles/pull/122)
+      and [#124](https://github.com/grunt-lucas/porytiles/pull/124)
 
 - Numerous other small bugfixes, refactors, and tweaks
 

--- a/Porytiles-0.x/lib/include/porytiles/types.h
+++ b/Porytiles-0.x/lib/include/porytiles/types.h
@@ -107,6 +107,11 @@ struct RGBA32 {
         return std::to_string(red) + " " + std::to_string(green) + " " + std::to_string(blue);
     }
 
+    [[nodiscard]] bool equalsIgnoringAlphaChannel(const RGBA32 &other) const
+    {
+        return this->red == other.red && this->green == other.green && this->blue == other.blue;
+    }
+
     auto operator<=>(const RGBA32 &rgba) const = default;
 
     friend std::ostream &operator<<(std::ostream &os, const RGBA32 &rgba);

--- a/Porytiles-0.x/lib/src/compiler.cpp
+++ b/Porytiles-0.x/lib/src/compiler.cpp
@@ -24,51 +24,67 @@
 #include "types.h"
 
 namespace porytiles {
+
+/**
+ * Insert an rgba32 color into a normalized palette. The color will be converted to bgr15 format in the process,
+ * and possibly deduped (depending on user settings). Transparent alpha pixels will be treated as transparent, as
+ * will pixels that are of transparent color (again, set by the user but default to magenta). Fails if a tile
+ * contains too many unique colors or if an invalid alpha value is detected.
+ */
 static std::size_t insertRGBA(PorytilesContext &ctx, CompilerMode compilerMode, const RGBATile &rgbaFrame,
                               const RGBA32 &transparencyColor, NormalizedPalette &palette, const RGBA32 &rgba,
                               std::size_t row, std::size_t col, bool errWarn)
 {
-    auto transparencyBgr = rgbaToBgr(transparencyColor);
-    if (rgba != transparencyColor && rgbaToBgr(rgba) == transparencyBgr && errWarn) {
-        if (rgba.red != transparencyColor.red || rgba.green != transparencyColor.green ||
-            rgba.blue != transparencyColor.blue) {
-            /*
-             * If we hit this case, it's almost certainly a user mistake so let's push an error. We would prefer to err
-             * on the side of forcing the user to be explicit, especially when it comes to transparency handling.
-             */
-            warn_nonTransparentRgbaCollapsedToTransparentBgr(ctx.err, compilerMode, rgbaFrame, row, col, rgba,
-                                                             transparencyColor);
-        }
-    }
+    const auto transparencyBgr = rgbaToBgr(transparencyColor);
+    const auto pixelBgr = rgbaToBgr(rgba);
+
     /*
-     * Insert an rgba32 color into a normalized palette. The color will be converted to bgr15 format in the process,
-     * and possibly deduped (depending on user settings). Transparent alpha pixels will be treated as transparent, as
-     * will pixels that are of transparent color (again, set by the user but default to magenta). Fails if a tile
-     * contains too many unique colors or if an invalid alpha value is detected.
+     * Porytiles does not allow users to specify an alpha value that isn't fully opaque or transparent.
      */
+    if (rgba.alpha != ALPHA_TRANSPARENT && rgba.alpha != ALPHA_OPAQUE) {
+        if (errWarn) {
+            error_invalidAlphaValue(ctx.err, rgbaFrame, rgba.alpha, row, col);
+        }
+        return INVALID_INDEX_PIXEL_VALUE;
+    }
+
+    if (!rgba.equalsIgnoringAlphaChannel(transparencyColor) && pixelBgr == transparencyBgr && errWarn) {
+        /*
+         * Porytiles has gone through a few iterations of behavior when it hits this case. Originally, this was a
+         * compilation error. Later, it became a warning that would not stop compilation, but would insert the bgr into
+         * the regular colors section of the NormalizedPalette. However, that behavior made for an extremely unintuitive
+         * user experience. We have settled on this behavior: if a pixel collapses to transparent under BGR conversion,
+         * then treat it as transparent but warn the user in case this was not their intention. This is the best option
+         * because it retains end-user visibility while not potentially causing confounding compilation errors later on
+         * in the compilation pipeline.
+         */
+        warn_nonTransparentRgbaCollapsedToTransparentBgr(ctx.err, compilerMode, rgbaFrame, row, col, rgba,
+                                                         transparencyColor);
+        return 0;
+    }
+
     if (rgba.alpha == ALPHA_TRANSPARENT || rgba == transparencyColor) {
         return 0;
     }
-    else if (rgba.alpha == ALPHA_OPAQUE) {
-        auto bgr = rgbaToBgr(rgba);
 
-        if (ctx.compilerContext.bgrToRgba.contains(bgr) && std::get<0>(ctx.compilerContext.bgrToRgba.at(bgr)) != rgba) {
+    if (rgba.alpha == ALPHA_OPAQUE) {
+        if (ctx.compilerContext.bgrToRgba.contains(pixelBgr) &&
+            std::get<0>(ctx.compilerContext.bgrToRgba.at(pixelBgr)) != rgba) {
             /*
              * We lost color precision here, so let's warn the user that two distinct RGBA colors they used
              * in the master sheet are going to collapse to one BGR color on the GBA.
              */
             if (errWarn) {
-                warn_colorPrecisionLoss(ctx.err, compilerMode, rgbaFrame, row, col, bgr, rgba,
-                                        ctx.compilerContext.bgrToRgba.at(bgr));
+                warn_colorPrecisionLoss(ctx.err, compilerMode, rgbaFrame, row, col, pixelBgr, rgba,
+                                        ctx.compilerContext.bgrToRgba.at(pixelBgr));
             }
-            ctx.compilerContext.bgrToRgba.at(bgr) =
-                std::tuple<RGBA32, RGBATile, std::size_t, std::size_t>{rgba, rgbaFrame, row, col};
+            ctx.compilerContext.bgrToRgba.at(pixelBgr) = std::tuple{rgba, rgbaFrame, row, col};
         }
-        ctx.compilerContext.bgrToRgba.insert_or_assign(
-            bgr, std::tuple<RGBA32, RGBATile, std::size_t, std::size_t>{rgba, rgbaFrame, row, col});
+        ctx.compilerContext.bgrToRgba.insert_or_assign(pixelBgr, std::tuple{rgba, rgbaFrame, row, col});
 
-        auto itrAtBgr = std::find(std::begin(palette.colors) + 1, std::begin(palette.colors) + palette.size, bgr);
-        auto bgrPosInPalette = itrAtBgr - std::begin(palette.colors);
+        const auto itrAtBgr =
+            std::find(std::begin(palette.colors) + 1, std::begin(palette.colors) + palette.size, pixelBgr);
+        const auto bgrPosInPalette = itrAtBgr - std::begin(palette.colors);
         if (bgrPosInPalette == palette.size) {
             // palette size will grow as we add to it
             if (palette.size == PAL_SIZE) {
@@ -77,16 +93,13 @@ static std::size_t insertRGBA(PorytilesContext &ctx, CompilerMode compilerMode, 
                 }
                 return INVALID_INDEX_PIXEL_VALUE;
             }
-            palette.colors.at(palette.size++) = bgr;
+            palette.colors.at(palette.size++) = pixelBgr;
         }
         return bgrPosInPalette;
     }
-    else {
-        if (errWarn) {
-            error_invalidAlphaValue(ctx.err, rgbaFrame, rgba.alpha, row, col);
-        }
-        return INVALID_INDEX_PIXEL_VALUE;
-    }
+
+    internalerror("compiler::insertRGBA unreachable code path");
+    return INVALID_INDEX_PIXEL_VALUE;
 }
 
 static NormalizedTile candidate(PorytilesContext &ctx, CompilerMode compilerMode, const RGBA32 &transparencyColor,


### PR DESCRIPTION
When issuing this warning, Porytiles now treats the offending color as transparent, even though it's technically not. In the end, this leads to a better user experience. We warn the user in case this wasn't their intention.

Closes #123 