### PR TITLE
Fix panics when decompiler encountered attributes that were out of range

### DIFF
--- a/Porytiles1/include/porytiles/diagnostics/diagnostics.hpp
+++ b/Porytiles1/include/porytiles/diagnostics/diagnostics.hpp
@@ -217,6 +217,7 @@ constexpr auto WarnTransparencyCollapse = "transparency-collapse";
 constexpr auto WarnUnusedManualPalColor = "unused-manual-pal-color";
 constexpr auto WarnTileIndexOutOfRange = "tile-index-out-of-range";
 constexpr auto WarnPaletteIndexOutOfRange = "palette-index-out-of-range";
+constexpr auto WarnAttributeOutOfRange = "attribute-out-of-range";
 
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/Porytiles1/include/porytiles/legacy/cli_options.h
+++ b/Porytiles1/include/porytiles/legacy/cli_options.h
@@ -469,6 +469,11 @@ const std::string WNO_PALETTE_INDEX_OUT_OF_RANGE = W_GENERAL + "no-" + WarnPalet
 constexpr int WPALETTE_INDEX_OUT_OF_RANGE_VAL = 70120;
 constexpr int WNO_PALETTE_INDEX_OUT_OF_RANGE_VAL = 80120;
 
+const std::string WATTRIBUTE_OUT_OF_RANGE = W_GENERAL + WarnAttributeOutOfRange;
+const std::string WNO_ATTRIBUTE_OUT_OF_RANGE = W_GENERAL + "no-" + WarnAttributeOutOfRange;
+constexpr int WATTRIBUTE_OUT_OF_RANGE_VAL = 70130;
+constexpr int WNO_ATTRIBUTE_OUT_OF_RANGE_VAL = 80130;
+
 // @formatter:on
 // clang-format on
 

--- a/Porytiles1/include/porytiles/legacy/types.h
+++ b/Porytiles1/include/porytiles/legacy/types.h
@@ -6,6 +6,7 @@
 #include <cstdint>
 #include <filesystem>
 #include <fmt/format.h>
+#include <optional>
 #include <png.hpp>
 #include <string>
 #include <tuple>
@@ -165,18 +166,21 @@ enum class LayerType { NORMAL, COVERED, SPLIT, TRIPLE };
 std::string layerTypeString(LayerType layerType);
 std::uint8_t layerTypeValue(LayerType layerType);
 LayerType layerTypeFromInt(std::uint8_t layerInt);
+std::optional<LayerType> layerTypeFromIntNoPanic(std::uint8_t layerInt);
 
 enum class EncounterType { NONE, LAND, WATER };
 std::uint8_t encounterTypeValue(EncounterType encounterType);
 std::string encounterTypeString(EncounterType encounterType);
 EncounterType stringToEncounterType(const std::string &string);
 EncounterType encounterTypeFromInt(std::uint8_t encounterInt);
+std::optional<EncounterType> encounterTypeFromIntNoPanic(std::uint8_t encounterInt);
 
 enum class TerrainType { NORMAL, GRASS, WATER, WATERFALL };
 std::uint8_t terrainTypeValue(TerrainType terrainType);
 std::string terrainTypeString(TerrainType terrainType);
 TerrainType stringToTerrainType(const std::string &string);
 TerrainType terrainTypeFromInt(std::uint8_t terrainInt);
+std::optional<TerrainType> terrainTypeFromIntNoPanic(std::uint8_t terrainInt);
 
 enum class TargetBaseGame { EMERALD, FIRERED, RUBY };
 std::string targetBaseGameString(TargetBaseGame game);

--- a/Porytiles1/lib/diagnostics/diagnostics.cpp
+++ b/Porytiles1/lib/diagnostics/diagnostics.cpp
@@ -428,6 +428,13 @@ static const DiagTempl W_PALETTE_INDEX_OUT_OF_RANGE_TEMPL{
     }
 };
 
+static const DiagTempl W_ATTRIBUTE_OUT_OF_RANGE_TEMPL{
+    WarnAttributeOutOfRange,
+    DiagLevel::Warning,
+    "{} metatile id '{}': attribute value '{}' out of range for attribute {}",
+    {DiagTempl{"attribute-out-of-range-note", DiagLevel::Note,
+               "substituting 0 so decompilation can continue"}}};
+
 static const DiagTempl E_GENERIC_TEMPL{ErrGeneric, DiagLevel::Error, "{}", {}};
 
 static const DiagTempl E_FATAL_GENERIC_TEMPL{FatalGeneric, DiagLevel::Fatal, "{}", {}};
@@ -449,6 +456,7 @@ static const std::unordered_map<const char *, DiagTempl> DIAG_TEMPLS{
     // Tileset decompilation warnings
     {WarnTileIndexOutOfRange, W_TILE_INDEX_OUT_OF_RANGE_TEMPL},
     {WarnPaletteIndexOutOfRange, W_PALETTE_INDEX_OUT_OF_RANGE_TEMPL},
+    {WarnAttributeOutOfRange, W_ATTRIBUTE_OUT_OF_RANGE_TEMPL},
 
     // Generic errors
     {ErrGeneric, E_GENERIC_TEMPL},

--- a/Porytiles1/lib/legacy/cli_parser.cpp
+++ b/Porytiles1/lib/legacy/cli_parser.cpp
@@ -806,6 +806,9 @@ static void parseSubcommandOptions(PorytilesContext &ctx, int argc, char *const 
         {WPALETTE_INDEX_OUT_OF_RANGE.c_str(), no_argument, nullptr, WPALETTE_INDEX_OUT_OF_RANGE_VAL},
         {WNO_PALETTE_INDEX_OUT_OF_RANGE.c_str(), no_argument, nullptr, WNO_PALETTE_INDEX_OUT_OF_RANGE_VAL},
 
+        {WATTRIBUTE_OUT_OF_RANGE.c_str(), no_argument, nullptr, WATTRIBUTE_OUT_OF_RANGE_VAL},
+        {WNO_ATTRIBUTE_OUT_OF_RANGE.c_str(), no_argument, nullptr, WNO_ATTRIBUTE_OUT_OF_RANGE_VAL},
+
         // Help
         {HELP.c_str(), no_argument, nullptr, HELP_VAL},
         {HELP_SHORT.c_str(), no_argument, nullptr, HELP_VAL},
@@ -1072,6 +1075,8 @@ static void parseSubcommandOptions(PorytilesContext &ctx, int argc, char *const 
                     ctx.diag->EnableAtLevel(WarnTileIndexOutOfRange, DiagLevel::Error);
                 } else if (strcmp(optarg, WarnPaletteIndexOutOfRange) == 0) {
                     ctx.diag->EnableAtLevel(WarnPaletteIndexOutOfRange, DiagLevel::Error);
+                } else if (strcmp(optarg, WarnAttributeOutOfRange) == 0) {
+                    ctx.diag->EnableAtLevel(WarnAttributeOutOfRange, DiagLevel::Error);
                 } else {
                     const auto msg = fmt::format("invalid argument '{}' for option '{}'",
                                                  ctx.diag->Bold(std::string{optarg}), ctx.diag->Bold(WERROR));
@@ -1105,6 +1110,8 @@ static void parseSubcommandOptions(PorytilesContext &ctx, int argc, char *const 
                 ctx.diag->DisableAtLevel(WarnTileIndexOutOfRange, DiagLevel::Error);
             } else if (strcmp(optarg, WarnPaletteIndexOutOfRange) == 0) {
                 ctx.diag->DisableAtLevel(WarnPaletteIndexOutOfRange, DiagLevel::Error);
+            } else if (strcmp(optarg, WarnAttributeOutOfRange) == 0) {
+                ctx.diag->DisableAtLevel(WarnAttributeOutOfRange, DiagLevel::Error);
             } else {
                 const auto msg = fmt::format("invalid argument '{}' for option '{}'",
                                              ctx.diag->Bold(std::string{optarg}), ctx.diag->Bold(WERROR));
@@ -1194,6 +1201,14 @@ static void parseSubcommandOptions(PorytilesContext &ctx, int argc, char *const 
         case WNO_PALETTE_INDEX_OUT_OF_RANGE_VAL:
             validateSubcommandContext(ctx, WNO_PALETTE_INDEX_OUT_OF_RANGE);
             ctx.diag->DisableAtLevel(WarnPaletteIndexOutOfRange, DiagLevel::Warning);
+            break;
+        case WATTRIBUTE_OUT_OF_RANGE_VAL:
+            validateSubcommandContext(ctx, WATTRIBUTE_OUT_OF_RANGE);
+            ctx.diag->EnableAtLevel(WarnAttributeOutOfRange, DiagLevel::Warning);
+            break;
+        case WNO_ATTRIBUTE_OUT_OF_RANGE_VAL:
+            validateSubcommandContext(ctx, WNO_ATTRIBUTE_OUT_OF_RANGE);
+            ctx.diag->DisableAtLevel(WarnAttributeOutOfRange, DiagLevel::Warning);
             break;
 
         // Help message upon '-h/--help' goes to stdout

--- a/Porytiles1/lib/legacy/importer.cpp
+++ b/Porytiles1/lib/legacy/importer.cpp
@@ -1018,15 +1018,59 @@ importCompiledMetatileAttributes(PorytilesContext &ctx, DecompilerMode mode, std
             std::uint32_t byte3 = attributesDataBuf.at((metatileIndex * BYTES_PER_ATTRIBUTE_FIRERED) + 3);
             std::uint32_t attribute = (byte3 << 24) | (byte2 << 16) | (byte1 << 8) | byte0;
             attributes.metatileBehavior = attribute & 0x000001FF;
-            attributes.terrainType = terrainTypeFromInt((attribute >> 9) & 0x0000001F);
-            attributes.encounterType = encounterTypeFromInt((attribute >> 24) & 0x00000007);
-            attributes.layerType = layerTypeFromInt((attribute >> 29) & 0x00000003);
+
+            // Parse terrain type and emit warning if out of range
+            std::uint8_t terrainTypeInt = (attribute >> 9) & 0x0000001F;
+            auto maybe_terrain_type = terrainTypeFromIntNoPanic(terrainTypeInt);
+            if (!maybe_terrain_type.has_value()) {
+                ctx.diag->Report(WarnAttributeOutOfRange, ctx.diag->Bold(decompilerModeString(mode)),
+                                 ctx.diag->Bold(metatileIndex), ctx.diag->Bold(terrainTypeInt),
+                                 ctx.diag->Bold("TerrainType"));
+                attributes.terrainType = TerrainType::NORMAL;
+            } else {
+                attributes.terrainType = maybe_terrain_type.value();
+            }
+
+            // Parse encounter type and emit warning if out of range
+            std::uint8_t encounterTypeInt = (attribute >> 24) & 0x00000007;
+            auto maybe_encounter_type = encounterTypeFromIntNoPanic(encounterTypeInt);
+            if (!maybe_encounter_type.has_value()) {
+                ctx.diag->Report(WarnAttributeOutOfRange, ctx.diag->Bold(decompilerModeString(mode)),
+                                 ctx.diag->Bold(metatileIndex), ctx.diag->Bold(encounterTypeInt),
+                                 ctx.diag->Bold("EncounterType"));
+                attributes.encounterType = EncounterType::NONE;
+            } else {
+                attributes.encounterType = maybe_encounter_type.value();
+            }
+
+            // Parse layer type and emit warning if out of range
+            std::uint8_t layerTypeInt = (attribute >> 29) & 0x00000003;
+            auto maybe_layer_type = layerTypeFromIntNoPanic(layerTypeInt);
+            if (!maybe_layer_type.has_value()) {
+                ctx.diag->Report(WarnAttributeOutOfRange, ctx.diag->Bold(decompilerModeString(mode)),
+                                 ctx.diag->Bold(metatileIndex), ctx.diag->Bold(layerTypeInt),
+                                 ctx.diag->Bold("LayerType"));
+                attributes.layerType = LayerType::NORMAL;
+            } else {
+                attributes.layerType = maybe_layer_type.value();
+            }
         } else {
             std::uint16_t byte0 = attributesDataBuf.at((metatileIndex * BYTES_PER_ATTRIBUTE_EMERALD));
             std::uint16_t byte1 = attributesDataBuf.at((metatileIndex * BYTES_PER_ATTRIBUTE_EMERALD) + 1);
             std::uint16_t attribute = (byte1 << 8) | byte0;
             attributes.metatileBehavior = attribute & 0x00FF;
-            attributes.layerType = layerTypeFromInt((attribute >> 12) & 0x000F);
+
+            // Parse layer type and emit warning if out of range
+            std::uint8_t layerTypeVal = (attribute >> 12) & 0x000F;
+            auto maybe_layer_type = layerTypeFromIntNoPanic(layerTypeVal);
+            if (!maybe_layer_type.has_value()) {
+                ctx.diag->Report(WarnAttributeOutOfRange, ctx.diag->Bold(decompilerModeString(mode)),
+                                 ctx.diag->Bold(metatileIndex), ctx.diag->Bold(layerTypeVal),
+                                 ctx.diag->Bold("LayerType"));
+                attributes.layerType = LayerType::NORMAL;
+            } else {
+                attributes.layerType = maybe_layer_type.value();
+            }
         }
         attributesMap.insert(std::pair{metatileIndex, attributes});
     }

--- a/Porytiles1/lib/legacy/types.cpp
+++ b/Porytiles1/lib/legacy/types.cpp
@@ -186,6 +186,21 @@ LayerType layerTypeFromInt(std::uint8_t layerInt) {
     throw std::runtime_error("types::layerTypeFromInt reached unreachable code path");
 }
 
+std::optional<LayerType> layerTypeFromIntNoPanic(std::uint8_t layerInt) {
+    switch (layerInt) {
+    case 0:
+        return LayerType::NORMAL;
+    case 1:
+        return LayerType::COVERED;
+    case 2:
+        return LayerType::SPLIT;
+    default:
+        return std::nullopt;
+    }
+    // unreachable, here for compiler
+    throw std::runtime_error("types::layerTypeFromInt reached unreachable code path");
+}
+
 std::uint8_t encounterTypeValue(EncounterType encounterType) {
     switch (encounterType) {
     case EncounterType::NONE:
@@ -239,6 +254,21 @@ EncounterType encounterTypeFromInt(std::uint8_t encounterInt) {
         return EncounterType::WATER;
     default:
         Panic("types::encounterTypeFromInt unknown EncounterType int " + std::to_string(encounterInt));
+    }
+    // unreachable, here for compiler
+    throw std::runtime_error("types::encounterTypeFromInt reached unreachable code path");
+}
+
+std::optional<EncounterType> encounterTypeFromIntNoPanic(std::uint8_t encounterInt) {
+    switch (encounterInt) {
+    case 0:
+        return EncounterType::NONE;
+    case 1:
+        return EncounterType::LAND;
+    case 2:
+        return EncounterType::WATER;
+    default:
+        return std::nullopt;
     }
     // unreachable, here for compiler
     throw std::runtime_error("types::encounterTypeFromInt reached unreachable code path");
@@ -304,6 +334,23 @@ TerrainType terrainTypeFromInt(std::uint8_t terrainInt) {
         return TerrainType::WATERFALL;
     default:
         Panic("types::terrainTypeFromInt unknown TerrainType int " + std::to_string(terrainInt));
+    }
+    // unreachable, here for compiler
+    throw std::runtime_error("types::terrainTypeFromInt reached unreachable code path");
+}
+
+std::optional<TerrainType> terrainTypeFromIntNoPanic(std::uint8_t terrainInt) {
+    switch (terrainInt) {
+    case 0:
+        return TerrainType::NORMAL;
+    case 1:
+        return TerrainType::GRASS;
+    case 2:
+        return TerrainType::WATER;
+    case 3:
+        return TerrainType::WATERFALL;
+    default:
+        return std::nullopt;
     }
     // unreachable, here for compiler
     throw std::runtime_error("types::terrainTypeFromInt reached unreachable code path");


### PR DESCRIPTION
Also adds new decompilation warning `-Wattribute-out-of-range`.

Closes #19.