### PR TITLE
Handle INCGFX incbin directive on imports plus add better diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,18 @@ All notable changes to Porytiles are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com),
 simplified to a single flat list of changes per version.
 
+<!--
+Entry format: one bullet per change, starting with a verb that signals the type:
+(Added / Changed / Fixed / Removed / Deprecated).
+End each entry with a link to its PR,
+and to its issue too when one was filed
+(some reports, e.g. Discord messages, have no issue and so link only the PR):
+  - Fixed ... ([#<issue>](https://github.com/grunt-lucas/porytiles/issues/<issue>), [#<pr>](https://github.com/grunt-lucas/porytiles/pull/<pr>))
+-->
+
 ## [Unreleased]
+
+- Fixed `import-tileset` failing to resolve artifact paths for tilesets declared with `INCGFX_*`-style macros (e.g. `INCGFX_U32`) - [#315](https://github.com/grunt-lucas/porytiles/pull/315)
 
 ## [1.0.0] - 2026-06-05
 

--- a/porytiles/include/porytiles/infra/services/project_tileset_metadata_provider.hpp
+++ b/porytiles/include/porytiles/infra/services/project_tileset_metadata_provider.hpp
@@ -1,10 +1,12 @@
 #pragma once
 
+#include <cstdint>
 #include <filesystem>
 #include <map>
 #include <set>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include "gsl/pointers"
 
@@ -16,6 +18,21 @@
 #include "porytiles/xcut/diagnostics/user_diagnostics.hpp"
 
 namespace porytiles {
+
+namespace detail {
+
+enum class IncbinResolutionFailure : std::uint8_t {
+    not_found,  // The variable name was not declared in any scanned source file.
+    empty_paths // The variable was found but its INCBIN declaration captured no paths.
+};
+
+struct UnresolvedIncbinVar {
+    std::string field_label;   // The struct field, e.g. ".tiles" or ".metatileAttributes".
+    std::string variable_name; // The INCBIN variable the field referenced.
+    IncbinResolutionFailure reason;
+};
+
+} // namespace detail
 
 /**
  * @brief Provides a pokeemerald project filesystem-based implementation for TilesetMetadataProvider.
@@ -94,6 +111,9 @@ class ProjectTilesetMetadataProvider : public TilesetMetadataProvider {
     // Lazy-loaded cache for resolved tileset artifact paths (mutable for const methods)
     mutable bool artifact_paths_parsed_{false};
     mutable std::map<std::string, ProjectTilesetArtifactPaths> tileset_artifact_paths_;
+
+    // Per-tileset record of artifact fields that failed INCBIN resolution, for diagnostics
+    mutable std::map<std::string, std::vector<detail::UnresolvedIncbinVar>> tileset_unresolved_vars_;
 };
 
 } // namespace porytiles

--- a/porytiles/lib/infra/services/project_tileset_metadata_provider.cpp
+++ b/porytiles/lib/infra/services/project_tileset_metadata_provider.cpp
@@ -1,9 +1,12 @@
 #include "porytiles/infra/services/project_tileset_metadata_provider.hpp"
 
+#include <array>
 #include <filesystem>
 #include <map>
+#include <optional>
 #include <set>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "porytiles/infra/models/project_tileset_metadata.hpp"
@@ -17,6 +20,7 @@
 namespace {
 
 using namespace porytiles;
+using namespace porytiles::detail;
 
 const std::filesystem::path headers_rel_path = std::filesystem::path{"src"} / "data" / "tilesets" / "headers.h";
 
@@ -24,6 +28,63 @@ const std::filesystem::path headers_rel_path = std::filesystem::path{"src"} / "d
 const std::filesystem::path graphics_rel_path = std::filesystem::path{"src"} / "data" / "tilesets" / "graphics.h";
 const std::filesystem::path metatiles_rel_path = std::filesystem::path{"src"} / "data" / "tilesets" / "metatiles.h";
 const std::filesystem::path src_graphics_rel_path = std::filesystem::path{"src"} / "graphics.c";
+
+/**
+ * @brief Classifies whether a single INCBIN variable resolves to at least one usable path.
+ */
+[[nodiscard]] std::optional<IncbinResolutionFailure>
+classify_incbin_lookup(const std::map<std::string, IncbinDeclaration> &incbin_vars, const std::string &variable_name)
+{
+    if (!incbin_vars.contains(variable_name)) {
+        return IncbinResolutionFailure::not_found;
+    }
+    if (incbin_vars.at(variable_name).paths().empty()) {
+        return IncbinResolutionFailure::empty_paths;
+    }
+    return std::nullopt;
+}
+
+/**
+ * @brief Builds a multi-line error explaining why a tileset's artifact paths could not be resolved.
+ *
+ * @details
+ * Lists each failed artifact field with the variable it referenced and the failure reason, then names the source
+ * files that were scanned so the user can locate (or add) the missing declaration.
+ */
+[[nodiscard]] FormattableError build_unresolved_artifact_paths_error(
+    const std::string &tileset_name, const std::vector<UnresolvedIncbinVar> &unresolved, const TextFormatter *format)
+{
+    std::vector<std::string> lines;
+
+    lines.push_back(
+        format->format("Could not resolve artifact paths for tileset '{}'.", FormatParam{tileset_name, Style::bold}));
+    lines.emplace_back("");
+    lines.emplace_back("The following INCBIN variable(s) could not be resolved:");
+
+    for (const auto &var : unresolved) {
+        if (var.reason == IncbinResolutionFailure::not_found) {
+            lines.push_back(format->format(
+                "  '{}' (field '{}') was not found in any scanned file.",
+                FormatParam{var.variable_name, Style::bold},
+                FormatParam{var.field_label, Style::bold}));
+        }
+        else {
+            lines.push_back(format->format(
+                "  '{}' (field '{}') was found but declared no INCBIN path.",
+                FormatParam{var.variable_name, Style::bold},
+                FormatParam{var.field_label, Style::bold}));
+        }
+    }
+
+    lines.emplace_back("");
+    lines.push_back(format->format(
+        "Scanned files: '{}', '{}', '{}'.",
+        FormatParam{graphics_rel_path.string(), Style::bold},
+        FormatParam{metatiles_rel_path.string(), Style::bold},
+        FormatParam{src_graphics_rel_path.string(), Style::bold}));
+
+    return FormattableError{std::move(lines)};
+}
 
 /**
  * @brief Ensures tileset metadata has been parsed from headers.h and cached.
@@ -109,6 +170,7 @@ const std::filesystem::path src_graphics_rel_path = std::filesystem::path{"src"}
  * @param tileset_metadata Mutable cache of parsed tileset metadata (must be populated first)
  * @param artifact_paths_parsed Mutable flag tracking whether artifact paths have been resolved
  * @param tileset_artifact_paths Mutable cache of resolved artifact paths
+ * @param tileset_unresolved_vars Mutable record of per-tileset artifact fields that failed INCBIN resolution
  * @param format Text formatter for styled output
  * @return Success or error result
  */
@@ -118,6 +180,7 @@ const std::filesystem::path src_graphics_rel_path = std::filesystem::path{"src"}
     std::map<std::string, ProjectTilesetMetadata> &tileset_metadata,
     bool &artifact_paths_parsed,
     std::map<std::string, ProjectTilesetArtifactPaths> &tileset_artifact_paths,
+    std::map<std::string, std::vector<UnresolvedIncbinVar>> &tileset_unresolved_vars,
     const TextFormatter *format)
 {
     if (artifact_paths_parsed) {
@@ -168,36 +231,47 @@ const std::filesystem::path src_graphics_rel_path = std::filesystem::path{"src"}
         incbin_vars.emplace(incbin.variable_name(), std::move(incbin));
     }
 
-    // Resolve paths per-tileset
+    // Resolve paths per-tileset, classifying each of the four artifact fields independently so that a failure can be
+    // reported with the exact field, variable, and reason for failure
     for (const auto &[tileset_name, metadata] : tileset_metadata) {
-        auto tiles_it = incbin_vars.find(metadata.tiles_var());
-        auto palettes_it = incbin_vars.find(metadata.palettes_var());
-        auto metatiles_it = incbin_vars.find(metadata.metatiles_var());
-        auto attrs_it = incbin_vars.find(metadata.metatile_attributes_var());
+        const std::array<std::pair<std::string, std::string>, 4> fields{{
+            {"tiles", metadata.tiles_var()},
+            {"palettes", metadata.palettes_var()},
+            {"metatiles", metadata.metatiles_var()},
+            {"metatileAttributes", metadata.metatile_attributes_var()},
+        }};
 
-        if (tiles_it == incbin_vars.end() || palettes_it == incbin_vars.end() || metatiles_it == incbin_vars.end() ||
-            attrs_it == incbin_vars.end()) {
+        std::vector<UnresolvedIncbinVar> unresolved;
+        for (const auto &[field_label, variable_name] : fields) {
+            auto failure = classify_incbin_lookup(incbin_vars, variable_name);
+            if (failure.has_value()) {
+                unresolved.push_back(UnresolvedIncbinVar{field_label, variable_name, failure.value()});
+            }
+        }
+
+        if (!unresolved.empty()) {
+            tileset_unresolved_vars.emplace(tileset_name, std::move(unresolved));
             continue;
         }
 
-        if (tiles_it->second.paths().empty() || palettes_it->second.paths().empty() ||
-            metatiles_it->second.paths().empty() || attrs_it->second.paths().empty()) {
-            continue;
-        }
+        const auto &tiles_incbin = incbin_vars.at(metadata.tiles_var());
+        const auto &palettes_incbin = incbin_vars.at(metadata.palettes_var());
+        const auto &metatiles_incbin = incbin_vars.at(metadata.metatiles_var());
+        const auto &attrs_incbin = incbin_vars.at(metadata.metatile_attributes_var());
 
         std::vector<std::filesystem::path> palette_paths;
-        palette_paths.reserve(palettes_it->second.paths().size());
-        for (const auto &path_str : palettes_it->second.paths()) {
+        palette_paths.reserve(palettes_incbin.paths().size());
+        for (const auto &path_str : palettes_incbin.paths()) {
             palette_paths.emplace_back(path_str);
         }
 
         tileset_artifact_paths.emplace(
             tileset_name,
             ProjectTilesetArtifactPaths{
-                std::filesystem::path{tiles_it->second.paths().front()},
+                std::filesystem::path{tiles_incbin.paths().front()},
                 std::move(palette_paths),
-                std::filesystem::path{metatiles_it->second.paths().front()},
-                std::filesystem::path{attrs_it->second.paths().front()}});
+                std::filesystem::path{metatiles_incbin.paths().front()},
+                std::filesystem::path{attrs_incbin.paths().front()}});
     }
 
     artifact_paths_parsed = true;
@@ -266,11 +340,16 @@ ProjectTilesetMetadataProvider::artifact_paths_for(const std::string &tileset_na
             tileset_metadata_,
             artifact_paths_parsed_,
             tileset_artifact_paths_,
+            tileset_unresolved_vars_,
             format_),
         ProjectTilesetArtifactPaths,
         format_->format("Failed to get artifact paths for tileset '{}'.", FormatParam{tileset_name, Style::bold}));
 
     if (!tileset_artifact_paths_.contains(tileset_name)) {
+        if (tileset_unresolved_vars_.contains(tileset_name)) {
+            return build_unresolved_artifact_paths_error(
+                tileset_name, tileset_unresolved_vars_.at(tileset_name), format_);
+        }
         return FormattableError{format_->format(
             "Could not resolve artifact paths for tileset '{}'.", FormatParam{tileset_name, Style::bold})};
     }
@@ -284,6 +363,7 @@ void ProjectTilesetMetadataProvider::invalidate_metadata_cache() const
     tileset_metadata_.clear();
     artifact_paths_parsed_ = false;
     tileset_artifact_paths_.clear();
+    tileset_unresolved_vars_.clear();
 }
 
 } // namespace porytiles

--- a/porytiles/lib/utilities/c_parser/parser.cpp
+++ b/porytiles/lib/utilities/c_parser/parser.cpp
@@ -122,6 +122,22 @@ namespace {
     return pos;
 }
 
+/**
+ * @brief Determines whether a token names a graphic-inclusion macro understood by the INCBIN parser.
+ *
+ * @details
+ * Recognizes the plain @c INCBIN_* family (e.g. @c INCBIN_U32) as well as the alternate form
+ * auto-conversion @c INCGFX_* family (e.g. @c INCGFX_U32). Both forms take the source/binary path as their
+ * first string-literal argument, so the parser handles them identically.
+ *
+ * @param token The macro identifier text to test.
+ * @return @c true if @p token begins with @c "INCBIN_" or @c "INCGFX_".
+ */
+[[nodiscard]] bool is_gfx_inclusion_macro(const std::string &token)
+{
+    return token.starts_with("INCBIN_") || token.starts_with("INCGFX_");
+}
+
 } // namespace
 
 FormattableError Parser::make_error(SourcePosition pos, std::string message) const
@@ -1303,7 +1319,7 @@ ChainableResult<std::vector<IncbinDeclaration>> Parser::parse_incbin_arrays()
                 }
 
                 std::string token_text = brace_contents[brace_pos].text();
-                if (token_text.find("INCBIN_") != 0) {
+                if (!is_gfx_inclusion_macro(token_text)) {
                     ++brace_pos;
                     continue;
                 }
@@ -1346,7 +1362,7 @@ ChainableResult<std::vector<IncbinDeclaration>> Parser::parse_incbin_arrays()
             }
 
             std::string token_text = peek().text();
-            if (token_text.find("INCBIN_") != 0) {
+            if (!is_gfx_inclusion_macro(token_text)) {
                 continue;
             }
             std::string macro_name = token_text;

--- a/porytiles/tests/integration/infra/services/project_tileset_metadata_provider_test.cpp
+++ b/porytiles/tests/integration/infra/services/project_tileset_metadata_provider_test.cpp
@@ -5,6 +5,7 @@
 #include <string>
 
 #include "porytiles/infra/services/project_tileset_metadata_provider.hpp"
+#include "porytiles/utilities/filesystem_utils.hpp"
 #include "porytiles/utilities/text/plain_text_formatter.hpp"
 #include "porytiles/xcut/diagnostics/buffered_user_diagnostics.hpp"
 
@@ -171,4 +172,51 @@ TEST_F(ProjectTilesetMetadataProviderTest_Fixture1, ArtifactPathsForReturnsCorre
         EXPECT_FALSE(paths.tiles_path().empty());
         EXPECT_FALSE(paths.metatiles_path().empty());
     }
+}
+
+class ProjectTilesetMetadataProviderTest_IncgfxTiles : public ProjectTilesetMetadataProviderTestBase {
+  protected:
+    [[nodiscard]] std::filesystem::path project_root_path() const override
+    {
+        return "resources/tests/integration/shared/repos/incgfx_tileset";
+    }
+};
+
+TEST_F(ProjectTilesetMetadataProviderTest_IncgfxTiles, ArtifactPathsForResolvesIncgfxTiles)
+{
+    auto result = metadata_provider_->artifact_paths_for("gTileset_VelvetForest");
+    ASSERT_TRUE(result.has_value()) << "INCGFX_U32-declared tiles should resolve. Got: "
+                                    << result.chain().back()->join(*formatter_);
+
+    const auto &paths = result.value();
+
+    // The parser captures INCGFX's first string-literal argument: the source PNG, not the compiled binary.
+    EXPECT_EQ(paths.tiles_path(), std::filesystem::path{"data/tilesets/primary/velvet_forest/tiles.png"});
+
+    // The importer turns the stored path into the PNG to load via strip_all_extensions(...) + ".png".
+    auto tiles_png = strip_all_extensions(paths.tiles_path());
+    tiles_png += ".png";
+    EXPECT_EQ(tiles_png, std::filesystem::path{"data/tilesets/primary/velvet_forest/tiles.png"});
+}
+
+class ProjectTilesetMetadataProviderTest_MissingVar : public ProjectTilesetMetadataProviderTestBase {
+  protected:
+    [[nodiscard]] std::filesystem::path project_root_path() const override
+    {
+        return "resources/tests/integration/shared/repos/missing_incbin_var";
+    }
+};
+
+TEST_F(ProjectTilesetMetadataProviderTest_MissingVar, ArtifactPathsForMissingVarReportsDiagnostic)
+{
+    auto result = metadata_provider_->artifact_paths_for("gTileset_Broken");
+    ASSERT_FALSE(result.has_value()) << "Resolution should fail when the tiles variable is undeclared.";
+
+    std::string error_text = result.chain().back()->join(*formatter_);
+    EXPECT_TRUE(error_text.find("gTilesetTiles_Broken") != std::string::npos)
+        << "Diagnostic should name the unresolved variable. Got: " << error_text;
+    EXPECT_TRUE(error_text.find("tiles") != std::string::npos)
+        << "Diagnostic should name the artifact field. Got: " << error_text;
+    EXPECT_TRUE(error_text.find("was not found in any scanned file") != std::string::npos)
+        << "Diagnostic should explain the failure reason. Got: " << error_text;
 }

--- a/porytiles/tests/unit/utilities/c_parser/parser_test.cpp
+++ b/porytiles/tests/unit/utilities/c_parser/parser_test.cpp
@@ -773,6 +773,37 @@ TEST_F(ParserTests, ParseStaticIncbinArray)
     EXPECT_EQ(result.value()[0].paths()[0], "data/tilesets/primary/general/anim/flower/0.4bpp");
 }
 
+TEST_F(ParserTests, ParseIncgfxArray)
+{
+    // pokeemerald-expansion's auto-conversion macro: first arg is the source PNG, second is the target extension.
+    auto result = parse_incbin_arrays(
+        R"(const u32 gTilesetTiles_velvet_forest[] = INCGFX_U32("data/tilesets/primary/velvet_forest/tiles.png", ".4bpp.lz");)");
+    ASSERT_TRUE(result.has_value());
+    ASSERT_EQ(result.value().size(), 1);
+    EXPECT_EQ(result.value()[0].variable_name(), "gTilesetTiles_velvet_forest");
+    EXPECT_EQ(result.value()[0].macro_name(), "INCGFX_U32");
+    ASSERT_EQ(result.value()[0].paths().size(), 1);
+    EXPECT_EQ(result.value()[0].paths().front(), "data/tilesets/primary/velvet_forest/tiles.png");
+}
+
+TEST_F(ParserTests, ParseIncgfxMultiPathArray)
+{
+    // The brace/multi-path branch must also accept INCGFX_*; only the first string literal of each call is captured.
+    auto result = parse_incbin_arrays(
+        R"(const u16 gTilesetPalettes_velvet_forest[][16] =
+{
+    INCGFX_U16("data/tilesets/primary/velvet_forest/palettes/00.png", ".gbapal"),
+    INCGFX_U16("data/tilesets/primary/velvet_forest/palettes/01.png", ".gbapal"),
+};)");
+    ASSERT_TRUE(result.has_value());
+    ASSERT_EQ(result.value().size(), 1);
+    EXPECT_EQ(result.value()[0].variable_name(), "gTilesetPalettes_velvet_forest");
+    EXPECT_EQ(result.value()[0].macro_name(), "INCGFX_U16");
+    ASSERT_EQ(result.value()[0].paths().size(), 2);
+    EXPECT_EQ(result.value()[0].paths()[0], "data/tilesets/primary/velvet_forest/palettes/00.png");
+    EXPECT_EQ(result.value()[0].paths()[1], "data/tilesets/primary/velvet_forest/palettes/01.png");
+}
+
 TEST_F(ParserTests, ParseFunctionsEmptyInput)
 {
     auto result = parse_functions("");

--- a/resources/tests/integration/shared/repos/incgfx_tileset/src/data/tilesets/graphics.h
+++ b/resources/tests/integration/shared/repos/incgfx_tileset/src/data/tilesets/graphics.h
@@ -1,0 +1,7 @@
+const u32 gTilesetTiles_VelvetForest[] = INCGFX_U32("data/tilesets/primary/velvet_forest/tiles.png", ".4bpp.lz");
+
+const u16 gTilesetPalettes_VelvetForest[][16] =
+{
+    INCBIN_U16("data/tilesets/primary/velvet_forest/palettes/00.gbapal"),
+    INCBIN_U16("data/tilesets/primary/velvet_forest/palettes/01.gbapal"),
+};

--- a/resources/tests/integration/shared/repos/incgfx_tileset/src/data/tilesets/headers.h
+++ b/resources/tests/integration/shared/repos/incgfx_tileset/src/data/tilesets/headers.h
@@ -1,0 +1,10 @@
+const struct Tileset gTileset_VelvetForest =
+{
+    .isCompressed = TRUE,
+    .isSecondary = FALSE,
+    .tiles = gTilesetTiles_VelvetForest,
+    .palettes = gTilesetPalettes_VelvetForest,
+    .metatiles = gMetatiles_VelvetForest,
+    .metatileAttributes = gMetatileAttributes_VelvetForest,
+    .callback = InitTilesetAnim_VelvetForest,
+};

--- a/resources/tests/integration/shared/repos/incgfx_tileset/src/data/tilesets/metatiles.h
+++ b/resources/tests/integration/shared/repos/incgfx_tileset/src/data/tilesets/metatiles.h
@@ -1,0 +1,2 @@
+const u16 gMetatiles_VelvetForest[] = INCBIN_U16("data/tilesets/primary/velvet_forest/metatiles.bin");
+const u16 gMetatileAttributes_VelvetForest[] = INCBIN_U16("data/tilesets/primary/velvet_forest/metatile_attributes.bin");

--- a/resources/tests/integration/shared/repos/incgfx_tileset/src/graphics.c
+++ b/resources/tests/integration/shared/repos/incgfx_tileset/src/graphics.c
@@ -1,0 +1,2 @@
+#include "global.h"
+#include "graphics.h"

--- a/resources/tests/integration/shared/repos/missing_incbin_var/src/data/tilesets/graphics.h
+++ b/resources/tests/integration/shared/repos/missing_incbin_var/src/data/tilesets/graphics.h
@@ -1,0 +1,7 @@
+// NOTE: gTilesetTiles_Broken is intentionally absent. The header references it, but no INCBIN/INCGFX
+// declaration exists for it in any scanned file, so artifact path resolution must fail with a diagnostic.
+
+const u16 gTilesetPalettes_Broken[][16] =
+{
+    INCBIN_U16("data/tilesets/primary/broken/palettes/00.gbapal"),
+};

--- a/resources/tests/integration/shared/repos/missing_incbin_var/src/data/tilesets/headers.h
+++ b/resources/tests/integration/shared/repos/missing_incbin_var/src/data/tilesets/headers.h
@@ -1,0 +1,10 @@
+const struct Tileset gTileset_Broken =
+{
+    .isCompressed = TRUE,
+    .isSecondary = FALSE,
+    .tiles = gTilesetTiles_Broken,
+    .palettes = gTilesetPalettes_Broken,
+    .metatiles = gMetatiles_Broken,
+    .metatileAttributes = gMetatileAttributes_Broken,
+    .callback = NULL,
+};

--- a/resources/tests/integration/shared/repos/missing_incbin_var/src/data/tilesets/metatiles.h
+++ b/resources/tests/integration/shared/repos/missing_incbin_var/src/data/tilesets/metatiles.h
@@ -1,0 +1,2 @@
+const u16 gMetatiles_Broken[] = INCBIN_U16("data/tilesets/primary/broken/metatiles.bin");
+const u16 gMetatileAttributes_Broken[] = INCBIN_U16("data/tilesets/primary/broken/metatile_attributes.bin");

--- a/resources/tests/integration/shared/repos/missing_incbin_var/src/graphics.c
+++ b/resources/tests/integration/shared/repos/missing_incbin_var/src/graphics.c
@@ -1,0 +1,2 @@
+#include "global.h"
+#include "graphics.h"


### PR DESCRIPTION
`import-tileset` failed with "Could not resolve artifact paths for tileset '...'" for any tileset whose tile graphics were declared with `INCGFX_*`-style macros (e.g. `INCGFX_U32(".../tiles.png", ".4bpp.lz")`) rather than plain `INCBIN_*`. The INCBIN parser looked at the literal `INCBIN_` prefix, so `INCGFX_*` declarations were skipped entirely, the artifact variables never made it into the lookup table, and the tileset was silently dropped during path resolution. The bug was reported on Discord so there's no corresponding issue.

We fixed it by changing the parser so it accepts both `INCBIN_*` and `INCGFX_*` prefixes. We also adjusted the artifact path resolver in `ProjectTilesetMetadataProvider` so that when resolution fails, we keep going and collect all errors, reporting them at the end. That way, the user sees a more helpful message explaining which path could not be resolved instead of just a generic "failed" message.