### PR TITLE
Fix for snake_case tileset names producing a mismatched anim callback symbol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and to its issue too when one was filed
 
 - Fixed `import-tileset` failing to resolve artifact paths for tilesets declared with `INCGFX_*`-style macros (e.g. `INCGFX_U32`) - [#315](https://github.com/grunt-lucas/porytiles/pull/315)
 
+- Fixed tileset names with a `snake_case` segment (e.g. `gTileset_velvet_forest`) producing a mismatched animation callback symbol in `headers.h`, where the `.callback` field kept the raw `snake_case` name while the generated init function used `PascalCase`, breaking the decomp build - [#317](https://github.com/grunt-lucas/porytiles/pull/317)
+
 ## [1.0.0] - 2026-06-05
 
 First stable release of Porytiles.

--- a/porytiles/include/porytiles/domain/models/animation.hpp
+++ b/porytiles/include/porytiles/domain/models/animation.hpp
@@ -5,12 +5,14 @@
 #include <ranges>
 #include <set>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "porytiles/domain/models/anim_frame.hpp"
 #include "porytiles/domain/models/anim_params.hpp"
 #include "porytiles/domain/models/supports_transparency.hpp"
 #include "porytiles/utilities/panic/panic.hpp"
+#include "porytiles/utilities/string_utils.hpp"
 #include "porytiles/utilities/text/text_formatter.hpp"
 
 namespace porytiles {
@@ -20,6 +22,17 @@ namespace anim {
 constexpr std::string g_tileset_anims_prefix = "gTilesetAnims_";
 constexpr std::string s_tileset_anims_prefix = "sTilesetAnims_";
 constexpr std::string porytiles_managed_prefix = "PorytilesManaged_";
+
+// "InitTilesetAnim_PorytilesManaged_": prefix of the init callback symbol Porytiles generates for a managed
+// tileset (i.e. "InitTilesetAnim_" + porytiles_managed_prefix). Used for both constructing and detecting it.
+constexpr std::string_view porytiles_managed_callback_prefix = "InitTilesetAnim_PorytilesManaged_";
+
+// Builds the Porytiles-managed init-callback symbol name for a tileset, e.g.
+// "gTileset_velvet_forest" -> "InitTilesetAnim_PorytilesManaged_VelvetForest".
+[[nodiscard]] inline std::string managed_callback_name(const std::string &tileset_name)
+{
+    return std::string{porytiles_managed_callback_prefix} + extract_tileset_cased_name(tileset_name).to_pascal_case();
+}
 
 [[nodiscard]] inline std::string message_header(
     const TextFormatter &format,

--- a/porytiles/lib/infra/repos/project_tileset_artifact_reader.cpp
+++ b/porytiles/lib/infra/repos/project_tileset_artifact_reader.cpp
@@ -228,7 +228,7 @@ ProjectTilesetArtifactReader::read_porymap_pal_n(Tileset &dest, const ArtifactKe
 
     // Setup callback info, use Porytiles-managed callback regardless of metadata
     const auto tileset_cased = extract_tileset_cased_name(dest.name());
-    const std::string callback_func = "InitTilesetAnim_PorytilesManaged_" + tileset_cased.to_pascal_case();
+    const std::string callback_func = anim::managed_callback_name(dest.name());
 
     // Parse C code for animation params
     PT_TRY_ASSIGN_CHAIN_ERR(

--- a/porytiles/lib/infra/services/project_porytiles_tileset_manager.cpp
+++ b/porytiles/lib/infra/services/project_porytiles_tileset_manager.cpp
@@ -6,8 +6,8 @@
 
 #include "nlohmann/json.hpp"
 
+#include "porytiles/domain/models/animation.hpp"
 #include "porytiles/domain/models/palette.hpp"
-#include "porytiles/utilities/string_utils.hpp"
 #include "porytiles/xcut/config/config_scope_type.hpp"
 
 namespace {
@@ -19,14 +19,12 @@ std::filesystem::path artifacts_file(const std::filesystem::path &project_root, 
     return project_root / "porytiles" / "tilesets" / tileset_name / "tileset-manifest.json";
 }
 
-constexpr std::string_view porytiles_managed_callback_prefix = "InitTilesetAnim_PorytilesManaged_";
-
 [[nodiscard]] bool is_porytiles_managed_callback(const std::optional<std::string> &callback)
 {
     if (!callback.has_value()) {
         return false;
     }
-    return callback->starts_with(porytiles_managed_callback_prefix);
+    return callback->starts_with(anim::porytiles_managed_callback_prefix);
 }
 
 ChainableResult<void> append_incbin_declarations(
@@ -236,9 +234,8 @@ ProjectPorytilesTilesetManager::wire_anim_code(const std::string &tileset_name, 
         "Failed to wire tileset_anims include/declaration for '{}'.",
         FormatParam(tileset_name, Style::bold));
 
-    // Step 2: Generate callback function name
-    const std::string shorthand = extract_tileset_shorthand(tileset_name);
-    const std::string callback_name = "InitTilesetAnim_PorytilesManaged_" + shorthand;
+    // Step 2: Generate callback function name (PascalCase, to match the generated function + declaration)
+    const std::string callback_name = anim::managed_callback_name(tileset_name);
 
     // Step 3: Update callback field in headers.h
     PT_TRY_CALL_CHAIN_ERR(

--- a/porytiles/tests/unit/utilities/string_utils_test.cpp
+++ b/porytiles/tests/unit/utilities/string_utils_test.cpp
@@ -2,6 +2,7 @@
 
 #include <string>
 
+#include "porytiles/domain/models/animation.hpp"
 #include "porytiles/utilities/dynamic_cased_name.hpp"
 #include "porytiles/utilities/string_utils.hpp"
 
@@ -158,4 +159,16 @@ TEST_F(StringUtilsTest, ExtractTilesetCasedNameCompound)
     auto result = extract_tileset_cased_name("gTileset_PetalburgCity");
     EXPECT_EQ(result.to_pascal_case(), "PetalburgCity");
     EXPECT_EQ(result.to_snake_case(), "petalburg_city");
+}
+
+TEST_F(StringUtilsTest, ManagedCallbackName)
+{
+    // snake_case-segmented names (the bug repro): the callback symbol must be PascalCase so it matches the
+    // generated function definition and forward declaration, not the raw snake_case shorthand.
+    EXPECT_EQ(anim::managed_callback_name("gTileset_velvet_forest"), "InitTilesetAnim_PorytilesManaged_VelvetForest");
+    EXPECT_EQ(
+        anim::managed_callback_name("gTileset_battle_frontier"), "InitTilesetAnim_PorytilesManaged_BattleFrontier");
+
+    // PascalCase input (every vanilla tileset) still converges to the same result.
+    EXPECT_EQ(anim::managed_callback_name("gTileset_General"), "InitTilesetAnim_PorytilesManaged_General");
 }


### PR DESCRIPTION
Importing a tileset whose name has a `snake_case` segment (e.g. `gTileset_velvet_forest`) wired a broken animation callback into `src/data/tilesets/headers.h`, breaking the decomp build. The `Tileset` struct's `.callback` referenced `InitTilesetAnim_PorytilesManaged_velvet_forest` (raw snake_case) while the generated anim code and its forward declaration defined `InitTilesetAnim_PorytilesManaged_VelvetForest` (PascalCase).

The root cause: four sites build the callback symbol, three of them run the tileset shorthand through `to_pascal_case()` while the struct `.callback` writer used the raw `extract_tileset_shorthand()` with no case conversion. The two derivations only diverge when a name segment is `snake_case`, and since every vanilla tileset is already PascalCase (`General`, `PetalburgCity`) the paths coincidentally agreed and the gap was never caught.

This consolidates the two construction sites behind a shared helper so the prefix + `to_pascal_case()` derivation lives in exactly one place.

No issue to link: the bug was reported by a user on Discord.