### PR TITLE
Fixed a same-named animation in a secondary and its paired primary aborting the compiler when cross-tileset animation linking is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and to its issue too when one was filed
 
 - Fixed tileset names with a `snake_case` segment (e.g. `gTileset_velvet_forest`) producing a mismatched animation callback symbol in `headers.h`, where the `.callback` field kept the raw `snake_case` name while the generated init function used `PascalCase`, breaking the decomp build - [#317](https://github.com/grunt-lucas/porytiles/pull/317)
 
+- Fixed a same-named animation in a secondary and its paired primary aborting the compiler with an internal panic instead of a diagnostic when cross-tileset animation linking is enabled - [#TODO](https://github.com/grunt-lucas/porytiles/pull/TODO)
+
 ## [1.0.0] - 2026-06-05
 
 First stable release of Porytiles.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and to its issue too when one was filed
 
 - Fixed tileset names with a `snake_case` segment (e.g. `gTileset_velvet_forest`) producing a mismatched animation callback symbol in `headers.h`, where the `.callback` field kept the raw `snake_case` name while the generated init function used `PascalCase`, breaking the decomp build - [#317](https://github.com/grunt-lucas/porytiles/pull/317)
 
-- Fixed a same-named animation in a secondary and its paired primary aborting the compiler with an internal panic instead of a diagnostic when cross-tileset animation linking is enabled - [#TODO](https://github.com/grunt-lucas/porytiles/pull/TODO)
+- Fixed a same-named animation in a secondary and its paired primary aborting the compiler with an internal panic instead of a diagnostic when cross-tileset animation linking is enabled - [#331](https://github.com/grunt-lucas/porytiles/pull/331)
 
 ## [1.0.0] - 2026-06-05
 

--- a/porytiles/lib/domain/services/tileset_compiler.cpp
+++ b/porytiles/lib/domain/services/tileset_compiler.cpp
@@ -1535,12 +1535,12 @@ ChainableResult<void> CompilerTask::pipeline_helper_register_animations()
         }
 
         // Check for stale compiled data: animations in porymap but removed from porytiles source
-        for (const auto &prim_anim_name : primary_porymap_anims | std::views::keys) {
-            if (!primary_porytiles_anims.contains(prim_anim_name)) {
+        for (const auto &primary_anim_name : primary_porymap_anims | std::views::keys) {
+            if (!primary_porytiles_anims.contains(primary_anim_name)) {
                 return FormattableError{std::vector<std::string>{
                     format_.format(
                         "Primary animation '{}' exists in compiled Porymap data but not in Porytiles source.",
-                        FormatParam{prim_anim_name, Style::bold}),
+                        FormatParam{primary_anim_name, Style::bold}),
                     "The paired primary tileset has uncompiled changes. Recompile it before compiling this "
                     "secondary."}};
             }
@@ -1567,6 +1567,25 @@ ChainableResult<void> CompilerTask::pipeline_helper_register_animations()
                 remark_lines.emplace_back("Cross-tileset key frame matching is not possible for this animation.");
                 diag_.remark("cross-tileset-anim-skip-no-keyframe", remark_lines);
                 continue;
+            }
+
+            /*
+             * Same-name collision check. A secondary-owned animation sharing a name with a paired-primary
+             * animation cannot coexist with cross-tileset linking: the anim_pal_indices_ write below would
+             * clobber the secondary's entry, and the matcher panics on cross-tileset name reuse as a backstop
+             * invariant. Checked after the key-frame skip above so manual-linking primary animations, which
+             * are never registered here, keep compiling as before.
+             */
+            if (anims.contains(prim_anim_name)) {
+                std::vector<std::string> err_msg{};
+                err_msg.emplace_back(format_.format(
+                    "Primary animation '{}' has the same name as a secondary animation.",
+                    FormatParam{prim_anim_name, Style::bold}));
+                err_msg.emplace_back(
+                    "Cross-tileset animation linking requires unique animation names across primary and secondary.");
+                err_msg.emplace_back("Rename the secondary (or primary) animation so the names are distinct.");
+                err_msg.append_range(format_config_note_with_separator(format_, cross_tileset_anim_linking_));
+                return FormattableError{err_msg};
             }
 
             const auto &prim_porymap_anim = primary_porymap_anims.at(prim_anim_name);

--- a/porytiles/notes/secondary_animation_handling.md
+++ b/porytiles/notes/secondary_animation_handling.md
@@ -179,6 +179,16 @@ index resolution so that the error path does not waste work on palette lookups. 
 each primary subtile and calls `find_match`. Any non-cross-tileset match (i.e. a secondary animation)
 triggers the error.
 
+A name-level check runs earlier in the same per-primary-animation loop: after the key frame skip (so
+manual-linking primary animations, which are never registered here, keep compiling) and before the RGBA
+art collision check and palette resolution. If a secondary animation shares a name with the primary
+animation, the compiler emits a fatal error requiring distinct names. This catches the same-name /
+different-art case that the RGBA art check cannot: two animations named `flower` with visually distinct
+key frames. Before this check existed, that input reached `register_animation` and aborted the compiler via
+the matcher's cross-tileset name panic (#328). Same-name / same-art is caught here by the name check first,
+which is correct: the art-collision guidance ("make key frames visually distinct") would be misleading when
+the real conflict is the shared name.
+
 ### Extrinsic transparency mismatch warning
 
 The use-case layer (`CompileSecondaryTileset::compile()`) now checks whether the secondary and paired
@@ -303,6 +313,14 @@ the code comments are the authoritative copies.
   intentional: two primary animations sharing subtile art would be a primary-side authoring
   mistake, and the primary compiler is responsible for its own validation. The secondary
   collision check exists only to protect the cross-tileset boundary.
+
+- **The matcher's cross-tileset name panic is a backstop, not the user-facing guard.**
+  `AnimTileMatcher::register_animation` panics when a cross-tileset animation reuses an
+  already-registered name. That panic is an internal invariant assertion: the user-facing guard is the
+  name-level check in `pipeline_helper_register_animations()`, which returns a `FormattableError` before
+  the primary animation is ever registered (#328). Do not "fix" the panic into a diagnostic or delete it;
+  it exists to catch any future caller that reaches `register_animation` with a colliding name without
+  going through the compiler-level check.
 
 - **`total_keyframe_tiles()` counts cross-tileset registrations.** `AnimTileMatcher::register_animation`
   increments `total_tiles_` for every call, including `is_cross_tileset=true` registrations. The

--- a/porytiles/tests/integration/domain/services/tileset_compiler_test.cpp
+++ b/porytiles/tests/integration/domain/services/tileset_compiler_test.cpp
@@ -4,8 +4,15 @@
 #include <string>
 
 #include "porytiles/domain/config/artifact_edit_mode.hpp"
+#include "porytiles/domain/models/anim_frame.hpp"
+#include "porytiles/domain/models/anim_params.hpp"
+#include "porytiles/domain/models/animation.hpp"
+#include "porytiles/domain/models/index_pixel.hpp"
+#include "porytiles/domain/models/palette.hpp"
+#include "porytiles/domain/models/pixel_tile.hpp"
 #include "porytiles/domain/models/porymap_tileset_component.hpp"
 #include "porytiles/domain/models/porytiles_tileset_component.hpp"
+#include "porytiles/domain/models/rgba32.hpp"
 #include "porytiles/domain/models/tileset.hpp"
 #include "porytiles/domain/services/tileset_compiler.hpp"
 #include "porytiles/infra/services/ascii_tile_printer.hpp"
@@ -26,9 +33,78 @@ Tileset build_empty_tileset(const std::string &name)
     return Tileset{name, std::move(porytiles_component), std::move(porymap_component)};
 }
 
+// Fills a PixelTile with a single solid color.
+PixelTile<Rgba32> make_solid_tile(const Rgba32 &color)
+{
+    PixelTile<Rgba32> tile;
+    for (std::size_t i = 0; i < tile::size_pix; ++i) {
+        tile.set(i, color);
+    }
+    return tile;
+}
+
+// Builds a single-subtile RGBA animation with a key frame and one regular frame, both a solid color.
+Animation<Rgba32> make_rgba_animation(const std::string &name, const Rgba32 &color)
+{
+    AnimParams params;
+    params.tile_count(1);
+
+    AnimFrame<Rgba32> key_frame{"key"};
+    key_frame.add_tile(make_solid_tile(color));
+
+    AnimFrame<Rgba32> frame0{"0"};
+    frame0.add_tile(make_solid_tile(color));
+
+    Animation<Rgba32> anim{name, params};
+    anim.key_frame(std::move(key_frame));
+    anim.put_frame("0", std::move(frame0));
+    return anim;
+}
+
+/*
+ * Builds a concrete (non-wildcard) Porymap palette whose slot 0 holds the mock extrinsic transparency color
+ * (rgba_magenta). Default-constructed Porymap palettes are all-wildcard and make validate_porymap_pal panic during
+ * input validation of the paired primary, so a paired-primary fixture must supply concrete palettes.
+ */
+Palette<Rgba32, pal::max_size> make_concrete_porymap_pal()
+{
+    Palette<Rgba32, pal::max_size> pal{rgba_black};
+    pal.set(0, rgba_magenta);
+    return pal;
+}
+
+/*
+ * Builds a minimal "compiled" primary tileset carrying one animation named anim_name.
+ *
+ * The Porytiles component holds the RGBA animation (with a key frame) so the secondary's cross-tileset registration
+ * passes both stale-primary checks. The Porymap component holds concrete palettes 0..num_pals-1 (so paired-primary
+ * palette validation passes) plus a name-only Animation<IndexPixel> of the same name (the other stale-primary check).
+ * The animation color is also placed in a non-slot-0 position of Porymap palette 0 so a cross-tileset primary anim
+ * whose subtile is unreferenced by any metatile can still resolve its palette via the RGBA fallback path.
+ */
+Tileset build_compiled_primary_with_anim(
+    const std::string &name, const std::string &anim_name, const Rgba32 &color, std::size_t num_pals)
+{
+    auto porytiles_component = std::make_unique<PorytilesTilesetComponent>();
+    porytiles_component->add_anim(make_rgba_animation(anim_name, color));
+
+    auto porymap_component = std::make_unique<PorymapTilesetComponent>();
+    for (std::size_t i = 0; i < num_pals; ++i) {
+        Palette<Rgba32, pal::max_size> pal = make_concrete_porymap_pal();
+        if (i == 0) {
+            // Place the anim color so the unreferenced primary subtile resolves via RGBA palette fallback.
+            pal.set(1, color);
+        }
+        porymap_component->set_pal(i, pal);
+    }
+    porymap_component->add_anim(Animation<IndexPixel>{anim_name});
+
+    return Tileset{name, std::move(porytiles_component), std::move(porymap_component)};
+}
+
 } // namespace
 
-class TilesetCompilerModeComboTests : public ::testing::Test {
+class TilesetCompilerTestBase : public ::testing::Test {
   protected:
     void SetUp() override
     {
@@ -63,6 +139,8 @@ class TilesetCompilerModeComboTests : public ::testing::Test {
     std::unique_ptr<ColorPalettePrinter> pal_printer_;
     MockDomainConfig config_;
 };
+
+class TilesetCompilerModeComboTests : public TilesetCompilerTestBase {};
 
 TEST_F(TilesetCompilerModeComboTests, PrimaryRejectsPalsOptimizeWithTilesLocked)
 {
@@ -134,4 +212,72 @@ TEST_F(TilesetCompilerModeComboTests, SecondaryRejectsPalsNonOptimize)
     EXPECT_NE(error_text.find("test_secondary"), std::string::npos)
         << "Expected tileset name in error, got: " << error_text;
     EXPECT_NE(error_text.find("locked"), std::string::npos) << "Expected 'locked' in error, got: " << error_text;
+}
+
+class TilesetCompilerCrossTilesetAnimTests : public TilesetCompilerTestBase {};
+
+/*
+ * Regression test for #328: a secondary animation sharing a name with a paired-primary animation but holding different
+ * art must produce a diagnostic, not abort the compiler via the matcher's cross-tileset name panic.
+ */
+TEST_F(TilesetCompilerCrossTilesetAnimTests, SecondarySameNamedAnimAsPrimaryReportsDiagnostic)
+{
+    config_.cross_tileset_anim_linking = true;
+
+    auto primary = build_compiled_primary_with_anim("test_primary", "flower", rgba_blue, config_.num_pals_in_primary);
+
+    auto secondary = build_empty_tileset("test_secondary");
+    secondary.porytiles_component().add_anim(make_rgba_animation("flower", rgba_red));
+
+    auto compiler = make_compiler();
+
+    auto result = compiler->compile(secondary, true, &primary);
+
+    ASSERT_FALSE(result.has_value());
+    const std::string error_text = join_error_chain(result);
+    EXPECT_NE(error_text.find("has the same name"), std::string::npos)
+        << "Expected 'has the same name' in error, got: " << error_text;
+    EXPECT_NE(error_text.find("flower"), std::string::npos) << "Expected 'flower' in error, got: " << error_text;
+    EXPECT_NE(error_text.find("Cross-Tileset Animation Linking"), std::string::npos)
+        << "Expected config note in error, got: " << error_text;
+}
+
+/*
+ * With cross-tileset linking disabled, the entire primary-registration block is skipped, so a same-named secondary and
+ * primary animation no longer collide and compilation succeeds.
+ */
+TEST_F(TilesetCompilerCrossTilesetAnimTests, SecondarySameNamedAnimCompilesWhenLinkingDisabled)
+{
+    config_.cross_tileset_anim_linking = false;
+
+    auto primary = build_compiled_primary_with_anim("test_primary", "flower", rgba_blue, config_.num_pals_in_primary);
+
+    auto secondary = build_empty_tileset("test_secondary");
+    secondary.porytiles_component().add_anim(make_rgba_animation("flower", rgba_red));
+
+    auto compiler = make_compiler();
+
+    auto result = compiler->compile(secondary, true, &primary);
+
+    ASSERT_TRUE(result.has_value()) << "Expected compile to succeed, got: " << join_error_chain(result);
+}
+
+/*
+ * A distinctly-named secondary animation must not trip the same-name check: with cross-tileset linking enabled and no
+ * name overlap, the primary animation registers cleanly and compilation succeeds.
+ */
+TEST_F(TilesetCompilerCrossTilesetAnimTests, DistinctlyNamedSecondaryAnimDoesNotOverFire)
+{
+    config_.cross_tileset_anim_linking = true;
+
+    auto primary = build_compiled_primary_with_anim("test_primary", "flower", rgba_blue, config_.num_pals_in_primary);
+
+    auto secondary = build_empty_tileset("test_secondary");
+    secondary.porytiles_component().add_anim(make_rgba_animation("flower_cave", rgba_red));
+
+    auto compiler = make_compiler();
+
+    auto result = compiler->compile(secondary, true, &primary);
+
+    ASSERT_TRUE(result.has_value()) << "Expected compile to succeed, got: " << join_error_chain(result);
 }


### PR DESCRIPTION
It used to panic, now it prints a diagnostic.

Closes #328 
