### PR TITLE
Fixed manual frame-linking overrides in `anim.json` aborting the compiler with an internal panic on an out-of-range `metatile_id`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and to its issue too when one was filed
 
 - Fixed a same-named animation in a secondary and its paired primary aborting the compiler with an internal panic instead of a diagnostic when cross-tileset animation linking is enabled - [#331](https://github.com/grunt-lucas/porytiles/pull/331)
 
+- Fixed manual frame-linking overrides in `anim.json` aborting the compiler with an internal panic on an out-of-range `metatile_id`, and gave the manual and `primary_references` override paths consistent validation: both now report graceful diagnostics for out-of-range `frame_subtile` and `metatile_id`, a `pal_index` that does not fit the hardware palette field, a `pal_index` past the configured palette count, and an override targeting a layer that dual-layer conversion drops. Also fixed a secondary that uses `primary_references` without defining any animations of its own having all of its overrides silently ignored - [#330](https://github.com/grunt-lucas/porytiles/issues/330)
+
 ## [1.0.0] - 2026-06-05
 
 First stable release of Porytiles.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and to its issue too when one was filed
 
 - Fixed a same-named animation in a secondary and its paired primary aborting the compiler with an internal panic instead of a diagnostic when cross-tileset animation linking is enabled - [#331](https://github.com/grunt-lucas/porytiles/pull/331)
 
-- Fixed manual frame-linking overrides in `anim.json` aborting the compiler with an internal panic on an out-of-range `metatile_id`, and gave the manual and `primary_references` override paths consistent validation: both now report graceful diagnostics for out-of-range `frame_subtile` and `metatile_id`, a `pal_index` that does not fit the hardware palette field, a `pal_index` past the configured palette count, and an override targeting a layer that dual-layer conversion drops. Also fixed a secondary that uses `primary_references` without defining any animations of its own having all of its overrides silently ignored - [#330](https://github.com/grunt-lucas/porytiles/issues/330)
+- Fixed manual frame-linking overrides in `anim.json` aborting the compiler with an internal panic on an out-of-range `metatile_id`, and gave the manual and `primary_references` override paths consistent validation: both now report graceful diagnostics for out-of-range `frame_subtile` and `metatile_id`, a `pal_index` that does not fit the hardware palette field, a `pal_index` past the configured palette count, and an override targeting a layer that dual-layer conversion drops. Also fixed a secondary that uses `primary_references` without defining any animations of its own having all of its overrides silently ignored - [#332](https://github.com/grunt-lucas/porytiles/pull/332)
 
 ## [1.0.0] - 2026-06-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and to its issue too when one was filed
 
 - Fixed a same-named animation in a secondary and its paired primary aborting the compiler with an internal panic instead of a diagnostic when cross-tileset animation linking is enabled - [#331](https://github.com/grunt-lucas/porytiles/pull/331)
 
-- Fixed manual frame-linking overrides in `anim.json` aborting the compiler with an internal panic on an out-of-range `metatile_id`, and gave the manual and `primary_references` override paths consistent validation: both now report graceful diagnostics for out-of-range `frame_subtile` and `metatile_id`, a `pal_index` that does not fit the hardware palette field, a `pal_index` past the configured palette count, and an override targeting a layer that dual-layer conversion drops. Also fixed a secondary that uses `primary_references` without defining any animations of its own having all of its overrides silently ignored - [#332](https://github.com/grunt-lucas/porytiles/pull/332)
+- Fixed manual frame-linking overrides in `anim.json` aborting the compiler with an internal panic on an out-of-range `metatile_id`, and gave the manual and `primary_references` override paths consistent validation: both now report diagnostics for out-of-range `frame_subtile` and `metatile_id`, a `pal_index` that does not fit the hardware palette field, a `pal_index` past the configured palette count, and an override targeting a layer that dual-layer conversion drops. Also fixed a secondary that uses `primary_references` without defining any animations of its own having all of its overrides silently ignored - [#332](https://github.com/grunt-lucas/porytiles/pull/332)
 
 ## [1.0.0] - 2026-06-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ and to its issue too when one was filed
 
 - Fixed a same-named animation in a secondary and its paired primary aborting the compiler with an internal panic instead of a diagnostic when cross-tileset animation linking is enabled - [#331](https://github.com/grunt-lucas/porytiles/pull/331)
 
-- Fixed manual frame-linking overrides in `anim.json` aborting the compiler with an internal panic on an out-of-range `metatile_id`, and gave the manual and `primary_references` override paths consistent validation: both now report diagnostics for out-of-range `frame_subtile` and `metatile_id`, a `pal_index` that does not fit the hardware palette field, a `pal_index` past the configured palette count, and an override targeting a layer that dual-layer conversion drops. Also fixed a secondary that uses `primary_references` without defining any animations of its own having all of its overrides silently ignored - [#332](https://github.com/grunt-lucas/porytiles/pull/332)
+- Fixed manual frame-linking overrides in `anim.json` aborting the compiler with an internal panic on an out-of-range `metatile_id`. Gave the manual and `primary_references` override paths consistent diagnostics: both now report for out-of-range `frame_subtile` and `metatile_id`, a `pal_index` that does not fit the hardware palette field, a `pal_index` past the configured palette count, and an override targeting a layer that dual-layer conversion drops. Also fixed a secondary that uses `primary_references` without defining any animations of its own having all of its overrides silently ignored - [#332](https://github.com/grunt-lucas/porytiles/pull/332)
 
 ## [1.0.0] - 2026-06-05
 

--- a/porytiles/include/porytiles/domain/models/metatile.hpp
+++ b/porytiles/include/porytiles/domain/models/metatile.hpp
@@ -42,6 +42,31 @@ inline std::ostream &operator<<(std::ostream &os, const Layer &layer)
     return os;
 }
 
+/**
+ * @brief Returns the layer that dual-layerization discards for a given inferred LayerType.
+ *
+ * @details
+ * Dual-layer mode renders only two of a metatile's three layers, chosen by the inferred LayerType: normal renders
+ * middle/top (bottom dropped), covered renders bottom/middle (top dropped), split renders bottom/top (middle dropped).
+ * Anything written to the dropped layer is lost during conversion, so callers use this to detect and warn about such
+ * writes. Mirrors the drop behavior of LayerModeConverter::dual_layerize.
+ *
+ * @param layer_type The inferred LayerType for the metatile
+ * @return The Layer that dual-layerization will drop
+ */
+[[nodiscard]] inline Layer dropped_layer_for(LayerType layer_type)
+{
+    switch (layer_type) {
+    case LayerType::normal:
+        return Layer::bottom;
+    case LayerType::covered:
+        return Layer::top;
+    case LayerType::split:
+        return Layer::middle;
+    }
+    panic("unhandled LayerType value in dropped_layer_for");
+}
+
 enum class Subtile : std::uint8_t { northwest = 0, northeast = 1, southwest = 2, southeast = 3 };
 
 [[nodiscard]] inline Subtile subtile_from_index(std::size_t i)

--- a/porytiles/lib/domain/services/tileset_compiler.cpp
+++ b/porytiles/lib/domain/services/tileset_compiler.cpp
@@ -22,10 +22,13 @@
 #include "porytiles/domain/config/packing_strategy_type.hpp"
 #include "porytiles/domain/config/per_anim_overrides.hpp"
 #include "porytiles/domain/config/tiles_pal_mode.hpp"
+#include "porytiles/domain/models/anim_override_entry.hpp"
 #include "porytiles/domain/models/canonical_pixel_tile.hpp"
 #include "porytiles/domain/models/color_index_map.hpp"
 #include "porytiles/domain/models/image.hpp"
 #include "porytiles/domain/models/index_pixel.hpp"
+#include "porytiles/domain/models/layer.hpp"
+#include "porytiles/domain/models/metatile.hpp"
 #include "porytiles/domain/models/palette.hpp"
 #include "porytiles/domain/models/rgba32.hpp"
 #include "porytiles/domain/models/tiles_png_workspace.hpp"
@@ -127,6 +130,157 @@ struct AnimKeyframeData {
     std::vector<const Palette<Rgba32, pal::max_size> *> palettes;
     std::vector<std::size_t> pal_indices;
 };
+
+/**
+ * @brief Per-path text used to tag and phrase override-validation diagnostics.
+ *
+ * @details
+ * The two override-application paths (manual frame linking and primary_references) share identical validation logic
+ * but differ in diagnostic tag prefix and message subject. This bundles those two per-path strings so the shared
+ * validator can compose path-appropriate diagnostics.
+ */
+struct OverridePathInfo {
+    /// Prefix for diagnostic tags, e.g. "manual" or "primary-references".
+    std::string tag_prefix;
+    /// Format string (one "{}" placeholder for the animation name) naming the override subject in messages.
+    std::string subject_template;
+};
+
+/**
+ * @brief Validates a single anim.json override entry before it is written to metatiles_bin.
+ *
+ * @details
+ * Both override-application paths route user-authored override entries through should_apply, which performs bounds and
+ * encodability checks and emits graceful diagnostics (never a panic) on bad input. This consolidates checks that
+ * previously diverged between the two paths: the manual path panicked on an out-of-range metatile_id and skipped the
+ * frame_subtile bound entirely, while neither path checked pal_index or warned about entries destined for a
+ * dual-layerization-dropped layer.
+ */
+class OverrideEntryValidator {
+  public:
+    OverrideEntryValidator(
+        const TextFormatter &format,
+        const UserDiagnostics &diag,
+        const ConfigValue<std::size_t> &num_pals_total,
+        LayerMode configured_layer_mode,
+        const std::vector<Metatile<Rgba32>> &source_metatiles,
+        Rgba32 extrinsic_transparency)
+        : format_{format}, diag_{diag}, num_pals_total_{num_pals_total}, configured_layer_mode_{configured_layer_mode},
+          source_metatiles_{source_metatiles}, extrinsic_transparency_{extrinsic_transparency}
+    {
+    }
+
+    /**
+     * @brief Validates one override entry and reports whether it should be written to metatiles_bin.
+     *
+     * @details
+     * Emits an error diagnostic and returns false for unrecoverable problems (frame_subtile out of range, metatile_id
+     * out of range, pal_index unencodable in the 4-bit hardware field). Emits a warning but returns true for a
+     * pal_index that references a configured-but-unmanaged palette slot. Emits a warning and returns false for an entry
+     * targeting a layer that dual-layerization will drop.
+     *
+     * @param path Per-path diagnostic tag prefix and message subject
+     * @param anim_name The animation name, substituted into the subject template
+     * @param entry The override entry to validate
+     * @param tile_count The number of tiles in the referenced animation (the frame_subtile upper bound)
+     * @return True if the entry passed validation and should be applied, false otherwise
+     */
+    [[nodiscard]] bool should_apply(
+        const OverridePathInfo &path,
+        const std::string &anim_name,
+        const AnimOverrideEntry &entry,
+        std::size_t tile_count) const;
+
+  private:
+    const TextFormatter &format_;
+    const UserDiagnostics &diag_;
+    const ConfigValue<std::size_t> &num_pals_total_;
+    LayerMode configured_layer_mode_;
+    const std::vector<Metatile<Rgba32>> &source_metatiles_;
+    Rgba32 extrinsic_transparency_;
+};
+
+bool OverrideEntryValidator::should_apply(
+    const OverridePathInfo &path,
+    const std::string &anim_name,
+    const AnimOverrideEntry &entry,
+    std::size_t tile_count) const
+{
+    const std::string subject = format_.format(path.subject_template, FormatParam{anim_name, Style::bold});
+
+    // 1. frame_subtile must index a real tile in the animation.
+    if (entry.frame_subtile >= tile_count) {
+        std::vector<std::string> lines;
+        lines.push_back(
+            subject + format_.format(
+                          " override has frame_subtile {} but the animation only has {} tiles.",
+                          FormatParam{entry.frame_subtile},
+                          FormatParam{tile_count}));
+        diag_.error(path.tag_prefix + "-frame-subtile-oob", lines);
+        return false;
+    }
+
+    // 2. metatile_id must be in range. This precedes the .at() in check 5.
+    if (entry.metatile_id >= source_metatiles_.size()) {
+        std::vector<std::string> lines;
+        lines.push_back(
+            subject +
+            format_.format(
+                " override references metatile_id {} which is out of range.", FormatParam{entry.metatile_id}));
+        lines.push_back(format_.format("This tileset has {} metatiles.", FormatParam{source_metatiles_.size()}));
+        diag_.error(path.tag_prefix + "-metatile-oob", lines);
+        return false;
+    }
+
+    // 3. pal_index must fit the 4-bit GBA palette field.
+    if (entry.pal_index >= pal::num_pals) {
+        std::vector<std::string> lines;
+        lines.push_back(
+            subject + format_.format(
+                          " override has pal_index {} but the maximum palette index is {}.",
+                          FormatParam{entry.pal_index},
+                          FormatParam{pal::num_pals - 1}));
+        lines.push_back(
+            format_.format("The GBA hardware only supports {} background palettes.", FormatParam{pal::num_pals}));
+        diag_.error(path.tag_prefix + "-pal-index-oob", lines);
+        return false;
+    }
+
+    // 4. pal_index is encodable but points past the configured palette count: warn, but still apply.
+    if (entry.pal_index >= num_pals_total_.value()) {
+        std::vector<std::string> lines;
+        lines.push_back(
+            subject + format_.format(
+                          " override has pal_index {} but only {} palettes are configured.",
+                          FormatParam{entry.pal_index},
+                          FormatParam{num_pals_total_.value()}));
+        lines.emplace_back(
+            "Porytiles does not manage palettes beyond the configured count, so this override will render with "
+            "whatever colors occupy that slot.");
+        lines.append_range(format_config_note_with_separator(format_, num_pals_total_));
+        diag_.warning(path.tag_prefix + "-pal-index-unused", lines);
+    }
+
+    // 5. In dual-layer mode, an entry targeting the dropped layer would silently vanish.
+    if (configured_layer_mode_ == LayerMode::dual) {
+        const LayerType inferred = source_metatiles_.at(entry.metatile_id).infer_layer_type(extrinsic_transparency_);
+        if (metatile::dropped_layer_for(inferred) == entry.layer) {
+            std::vector<std::string> lines;
+            lines.push_back(
+                subject + format_.format(
+                              " override targets the '{}' layer of metatile {} but dual-layer conversion drops that "
+                              "layer (inferred layer type '{}').",
+                              FormatParam{metatile::to_string(entry.layer)},
+                              FormatParam{entry.metatile_id},
+                              FormatParam{to_string(inferred)}));
+            lines.emplace_back("The override will be ignored.");
+            diag_.warning(path.tag_prefix + "-dual-layer-drop", lines);
+            return false;
+        }
+    }
+
+    return true;
+}
 
 /**
  * @brief Task encapsulating the compilation operation for primary tilesets.
@@ -1880,11 +2034,23 @@ void CompilerTask::pipeline_helper_compile_animations()
 void CompilerTask::pipeline_helper_apply_manual_overrides()
 {
     const auto &source_anims = tileset_.porytiles_component().anims();
-    if (source_anims.empty()) {
+    // Bail only when there is genuinely nothing to apply. A secondary can carry primary_references without defining any
+    // animations of its own, so guarding on source_anims alone would silently drop those overrides.
+    if (source_anims.empty() && tileset_.porytiles_component().primary_anim_overrides().empty()) {
         return;
     }
 
     const auto &per_anim_overrides = per_anim_overrides_.value();
+
+    const OverrideEntryValidator validator{
+        format_,
+        diag_,
+        num_pals_total_,
+        layer_mode_from_val(num_tiles_per_metatile_.value()),
+        porytiles_metatiles_,
+        extrinsic_transparency_.value()};
+    const OverridePathInfo manual_path{"manual", "Animation '{}'"};
+    const OverridePathInfo primary_refs_path{"primary-references", "Primary reference '{}'"};
 
     for (const auto &[anim_name, source_anim] : source_anims) {
         // Resolve effective FrameLinking for this animation
@@ -1920,29 +2086,33 @@ void CompilerTask::pipeline_helper_apply_manual_overrides()
                 break;
             }
 
-            // Get the tile_offset for this animation from the matcher
+            // Get the tile_offset and tile_count for this animation from the matcher
             auto maybe_tile_offset = anim_tile_matcher_.tile_offset_for(anim_name);
             if (!maybe_tile_offset.has_value()) {
                 panic("animation '" + anim_name + "' not registered in anim_tile_matcher_");
             }
             const std::size_t tile_offset = maybe_tile_offset.value();
 
+            auto maybe_tile_count = anim_tile_matcher_.tile_count_for(anim_name);
+            if (!maybe_tile_count.has_value()) {
+                panic("animation '" + anim_name + "' not registered in anim_tile_matcher_");
+            }
+            const std::size_t tile_count = maybe_tile_count.value();
+
             // Apply each override entry to metatiles_bin
             auto &metatiles_bin = new_porymap_component_->metatiles_bin();
             for (const auto &entry : overrides) {
+                if (!validator.should_apply(manual_path, anim_name, entry, tile_count)) {
+                    continue;
+                }
+
                 const std::size_t bin_index =
                     entry.metatile_id * metatile::entries_per_metatile_triple +
                     static_cast<std::size_t>(entry.layer) * metatile::tiles_per_metatile_layer +
                     static_cast<std::size_t>(entry.subtile);
 
-                if (bin_index >= metatiles_bin.size()) {
-                    panic(
-                        "animation '" + anim_name + "' override references metatile_id " +
-                        std::to_string(entry.metatile_id) + " which is out of range");
-                }
-
                 const std::size_t absolute_tile = tile_offset + entry.frame_subtile;
-                metatiles_bin[bin_index] = TilemapEntry{absolute_tile, entry.pal_index, entry.h_flip, entry.v_flip};
+                metatiles_bin.at(bin_index) = TilemapEntry{absolute_tile, entry.pal_index, entry.h_flip, entry.v_flip};
             }
             break;
         }
@@ -2003,14 +2173,7 @@ void CompilerTask::pipeline_helper_apply_manual_overrides()
             const std::size_t prim_tile_count = prim_anim.params().tile_count();
 
             for (const auto &entry : entries) {
-                if (entry.frame_subtile >= prim_tile_count) {
-                    std::vector<std::string> err_lines;
-                    err_lines.emplace_back(format_.format(
-                        "Primary reference '{}' override has frame_subtile {} but primary animation only has {} tiles.",
-                        FormatParam{prim_anim_name, Style::bold},
-                        FormatParam{entry.frame_subtile},
-                        FormatParam{prim_tile_count}));
-                    diag_.error("primary-references-frame-subtile-oob", err_lines);
+                if (!validator.should_apply(primary_refs_path, prim_anim_name, entry, prim_tile_count)) {
                     continue;
                 }
 
@@ -2018,16 +2181,6 @@ void CompilerTask::pipeline_helper_apply_manual_overrides()
                     entry.metatile_id * metatile::entries_per_metatile_triple +
                     static_cast<std::size_t>(entry.layer) * metatile::tiles_per_metatile_layer +
                     static_cast<std::size_t>(entry.subtile);
-
-                if (bin_index >= metatiles_bin.size()) {
-                    std::vector<std::string> err_lines;
-                    err_lines.emplace_back(format_.format(
-                        "Primary reference '{}' override references metatile_id {} which is out of range.",
-                        FormatParam{prim_anim_name, Style::bold},
-                        FormatParam{entry.metatile_id}));
-                    diag_.error("primary-references-metatile-oob", err_lines);
-                    continue;
-                }
 
                 const std::size_t absolute_tile = prim_tile_offset + entry.frame_subtile;
                 metatiles_bin.at(bin_index) = TilemapEntry{absolute_tile, entry.pal_index, entry.h_flip, entry.v_flip};

--- a/porytiles/notes/secondary_animation_handling.md
+++ b/porytiles/notes/secondary_animation_handling.md
@@ -164,6 +164,21 @@ Six diagnostics cover cross-tileset animation linking scenarios:
 Manual `primary_references` overrides always win. They write directly to `metatiles_bin` after the tile
 assignment loop, naturally overriding any automatically-linked entries.
 
+Each override entry is validated before it is written, sharing an `OverrideEntryValidator` with the manual
+frame-linking override path so the two paths stay in lockstep (#330). An out-of-range `frame_subtile` or
+`metatile_id`, or a `pal_index` that does not fit the 4-bit hardware palette field, produces an error
+diagnostic and skips the entry (`primary-references-frame-subtile-oob`, `-metatile-oob`, `-pal-index-oob`).
+A `pal_index` past the configured palette count warns but still applies
+(`primary-references-pal-index-unused`); an entry targeting a layer that dual-layer conversion drops warns
+and is skipped (`primary-references-dual-layer-drop`). The manual path emits the same set under a `manual-`
+prefix. None of these diagnostics abort the compile. Before this, the manual path panicked on an out-of-range
+`metatile_id` and skipped several checks the `primary_references` path already had.
+
+A secondary that uses `primary_references` without defining any animations of its own is fully supported.
+The override-application helper previously bailed as soon as the secondary had no animations of its own,
+silently dropping every `primary_references` entry; it now bails only when both the secondary's own
+animations and its `primary_references` are empty.
+
 ### Cross-tileset key frame collision detection
 
 When registering primary animations for cross-tileset linking, each non-transparent primary key frame

--- a/porytiles/tests/integration/domain/services/tileset_compiler_test.cpp
+++ b/porytiles/tests/integration/domain/services/tileset_compiler_test.cpp
@@ -4,10 +4,14 @@
 #include <string>
 
 #include "porytiles/domain/config/artifact_edit_mode.hpp"
+#include "porytiles/domain/config/frame_linking.hpp"
 #include "porytiles/domain/models/anim_frame.hpp"
+#include "porytiles/domain/models/anim_override_entry.hpp"
 #include "porytiles/domain/models/anim_params.hpp"
 #include "porytiles/domain/models/animation.hpp"
+#include "porytiles/domain/models/image.hpp"
 #include "porytiles/domain/models/index_pixel.hpp"
+#include "porytiles/domain/models/metatile.hpp"
 #include "porytiles/domain/models/palette.hpp"
 #include "porytiles/domain/models/pixel_tile.hpp"
 #include "porytiles/domain/models/porymap_tileset_component.hpp"
@@ -81,9 +85,17 @@ Palette<Rgba32, pal::max_size> make_concrete_porymap_pal()
  * palette validation passes) plus a name-only Animation<IndexPixel> of the same name (the other stale-primary check).
  * The animation color is also placed in a non-slot-0 position of Porymap palette 0 so a cross-tileset primary anim
  * whose subtile is unreferenced by any metatile can still resolve its palette via the RGBA fallback path.
+ *
+ * When porymap_anim_tile_count is nonzero, the Porymap animation carries tile_count/tile_offset params so a secondary's
+ * primary_references overrides can resolve the primary animation's tile range. It defaults to 0 (name-only) so existing
+ * call sites are unaffected.
  */
 Tileset build_compiled_primary_with_anim(
-    const std::string &name, const std::string &anim_name, const Rgba32 &color, std::size_t num_pals)
+    const std::string &name,
+    const std::string &anim_name,
+    const Rgba32 &color,
+    std::size_t num_pals,
+    std::size_t porymap_anim_tile_count = 0)
 {
     auto porytiles_component = std::make_unique<PorytilesTilesetComponent>();
     porytiles_component->add_anim(make_rgba_animation(anim_name, color));
@@ -97,9 +109,42 @@ Tileset build_compiled_primary_with_anim(
         }
         porymap_component->set_pal(i, pal);
     }
-    porymap_component->add_anim(Animation<IndexPixel>{anim_name});
+    if (porymap_anim_tile_count != 0) {
+        AnimParams porymap_params;
+        porymap_params.tile_count(porymap_anim_tile_count);
+        porymap_params.tile_offset(1);
+        porymap_component->add_anim(Animation<IndexPixel>{anim_name, porymap_params});
+    }
+    else {
+        porymap_component->add_anim(Animation<IndexPixel>{anim_name});
+    }
 
     return Tileset{name, std::move(porytiles_component), std::move(porymap_component)};
+}
+
+// Builds a primary tileset with exactly one metatile: transparent (extrinsic-transparency-filled) bottom and top
+// layers and a solid-color middle layer. The middle-only content infers LayerType::normal, so dual-layerization drops
+// the bottom layer.
+Tileset build_single_metatile_tileset(const std::string &name, const Rgba32 &middle_color)
+{
+    auto porytiles_component = std::make_unique<PorytilesTilesetComponent>();
+    porytiles_component->bottom(Image<Rgba32>{16, 16, rgba_magenta});
+    porytiles_component->middle(Image<Rgba32>{16, 16, middle_color});
+    porytiles_component->top(Image<Rgba32>{16, 16, rgba_magenta});
+
+    auto porymap_component = std::make_unique<PorymapTilesetComponent>();
+    return Tileset{name, std::move(porytiles_component), std::move(porymap_component)};
+}
+
+// Adds a manual-frame-linking RGBA animation (tile_count 1) carrying the given override entries to a tileset.
+void add_manual_anim(
+    Tileset &tileset, const std::string &anim_name, const Rgba32 &color, std::vector<AnimOverrideEntry> overrides)
+{
+    Animation<Rgba32> anim = make_rgba_animation(anim_name, color);
+    AnimParams params = anim.params();
+    params.overrides(std::move(overrides));
+    anim.params(std::move(params));
+    tileset.porytiles_component().add_anim(std::move(anim));
 }
 
 } // namespace
@@ -280,4 +325,349 @@ TEST_F(TilesetCompilerCrossTilesetAnimTests, DistinctlyNamedSecondaryAnimDoesNot
     auto result = compiler->compile(secondary, true, &primary);
 
     ASSERT_TRUE(result.has_value()) << "Expected compile to succeed, got: " << join_error_chain(result);
+}
+
+/*
+ * Coverage for #330: anim.json override entry validation parity between the manual and primary_references paths. Each
+ * override entry is now bounds- and encodability-checked through a shared validator that emits graceful diagnostics
+ * instead of panicking (the manual metatile-OOB case previously panicked). These diagnostics do not abort the compile,
+ * so every test below expects result.has_value() to remain true and asserts via the buffered diagnostic tag counts.
+ */
+class TilesetCompilerOverrideValidationTests : public TilesetCompilerTestBase {};
+
+TEST_F(TilesetCompilerOverrideValidationTests, ManualOverrideApplies)
+{
+    config_.global_frame_linking = FrameLinking::manual;
+
+    auto tileset = build_single_metatile_tileset("test_primary", rgba_green);
+    add_manual_anim(
+        tileset,
+        "anim",
+        rgba_red,
+        {AnimOverrideEntry{
+            .metatile_id = 0,
+            .layer = metatile::Layer::middle,
+            .subtile = metatile::Subtile::northwest,
+            .frame_subtile = 0,
+            .pal_index = 0,
+            .h_flip = true,
+            .v_flip = false}});
+
+    auto compiler = make_compiler();
+    auto result = compiler->compile(tileset, false, nullptr);
+
+    ASSERT_TRUE(result.has_value()) << "Expected compile to succeed, got: " << join_error_chain(result);
+    EXPECT_FALSE(diag_->error_tag_counts().contains("manual-frame-subtile-oob"));
+    EXPECT_FALSE(diag_->error_tag_counts().contains("manual-metatile-oob"));
+    EXPECT_FALSE(diag_->error_tag_counts().contains("manual-pal-index-oob"));
+    EXPECT_FALSE(diag_->warning_tag_counts().contains("manual-pal-index-unused"));
+    EXPECT_FALSE(diag_->warning_tag_counts().contains("manual-dual-layer-drop"));
+
+    // Dual mode with an inferred-normal metatile keeps [middle, top], so the overridden middle/NW entry lands at
+    // dual-layer index 0 with the animation's tile offset and the requested horizontal flip.
+    const std::size_t tile_offset = result.value()->porytiles_component().anim_for_name("anim").params().tile_offset();
+    const auto &bin = result.value()->porymap_component().metatiles_bin();
+    ASSERT_FALSE(bin.empty());
+    EXPECT_EQ(bin.at(0).tile_index(), tile_offset);
+    EXPECT_TRUE(bin.at(0).h_flip());
+}
+
+TEST_F(TilesetCompilerOverrideValidationTests, ManualFrameSubtileOobReportsError)
+{
+    config_.global_frame_linking = FrameLinking::manual;
+
+    auto tileset = build_single_metatile_tileset("test_primary", rgba_green);
+    add_manual_anim(
+        tileset,
+        "anim",
+        rgba_red,
+        {AnimOverrideEntry{
+            .metatile_id = 0,
+            .layer = metatile::Layer::middle,
+            .subtile = metatile::Subtile::northwest,
+            .frame_subtile = 5,
+            .pal_index = 0,
+            .h_flip = false,
+            .v_flip = false}});
+
+    auto compiler = make_compiler();
+    auto result = compiler->compile(tileset, false, nullptr);
+
+    ASSERT_TRUE(result.has_value()) << "Expected compile to succeed, got: " << join_error_chain(result);
+    ASSERT_TRUE(diag_->error_tag_counts().contains("manual-frame-subtile-oob"));
+    EXPECT_EQ(diag_->error_tag_counts().at("manual-frame-subtile-oob"), 1U);
+}
+
+TEST_F(TilesetCompilerOverrideValidationTests, ManualMetatileOobReportsError)
+{
+    config_.global_frame_linking = FrameLinking::manual;
+
+    auto tileset = build_single_metatile_tileset("test_primary", rgba_green);
+    add_manual_anim(
+        tileset,
+        "anim",
+        rgba_red,
+        {AnimOverrideEntry{
+            .metatile_id = 99,
+            .layer = metatile::Layer::middle,
+            .subtile = metatile::Subtile::northwest,
+            .frame_subtile = 0,
+            .pal_index = 0,
+            .h_flip = false,
+            .v_flip = false}});
+
+    auto compiler = make_compiler();
+    auto result = compiler->compile(tileset, false, nullptr);
+
+    // Regression: an out-of-range metatile_id previously aborted the compiler via panic().
+    ASSERT_TRUE(result.has_value()) << "Expected compile to succeed, got: " << join_error_chain(result);
+    ASSERT_TRUE(diag_->error_tag_counts().contains("manual-metatile-oob"));
+    EXPECT_EQ(diag_->error_tag_counts().at("manual-metatile-oob"), 1U);
+}
+
+TEST_F(TilesetCompilerOverrideValidationTests, ManualPalIndexUnencodableReportsError)
+{
+    config_.global_frame_linking = FrameLinking::manual;
+
+    auto tileset = build_single_metatile_tileset("test_primary", rgba_green);
+    add_manual_anim(
+        tileset,
+        "anim",
+        rgba_red,
+        {AnimOverrideEntry{
+            .metatile_id = 0,
+            .layer = metatile::Layer::middle,
+            .subtile = metatile::Subtile::northwest,
+            .frame_subtile = 0,
+            .pal_index = 16,
+            .h_flip = false,
+            .v_flip = false}});
+
+    auto compiler = make_compiler();
+    auto result = compiler->compile(tileset, false, nullptr);
+
+    ASSERT_TRUE(result.has_value()) << "Expected compile to succeed, got: " << join_error_chain(result);
+    ASSERT_TRUE(diag_->error_tag_counts().contains("manual-pal-index-oob"));
+    EXPECT_EQ(diag_->error_tag_counts().at("manual-pal-index-oob"), 1U);
+}
+
+TEST_F(TilesetCompilerOverrideValidationTests, ManualPalIndexUnconfiguredReportsWarning)
+{
+    config_.global_frame_linking = FrameLinking::manual;
+
+    auto tileset = build_single_metatile_tileset("test_primary", rgba_green);
+    add_manual_anim(
+        tileset,
+        "anim",
+        rgba_red,
+        {AnimOverrideEntry{
+            .metatile_id = 0,
+            .layer = metatile::Layer::middle,
+            .subtile = metatile::Subtile::northwest,
+            .frame_subtile = 0,
+            .pal_index = 14,
+            .h_flip = false,
+            .v_flip = false}});
+
+    auto compiler = make_compiler();
+    auto result = compiler->compile(tileset, false, nullptr);
+
+    ASSERT_TRUE(result.has_value()) << "Expected compile to succeed, got: " << join_error_chain(result);
+    ASSERT_TRUE(diag_->warning_tag_counts().contains("manual-pal-index-unused"));
+    EXPECT_EQ(diag_->warning_tag_counts().at("manual-pal-index-unused"), 1U);
+    EXPECT_TRUE(diag_->error_tag_counts().empty());
+
+    // A pal_index past the configured count is encodable, so the entry still applies.
+    const auto &bin = result.value()->porymap_component().metatiles_bin();
+    ASSERT_FALSE(bin.empty());
+    EXPECT_EQ(bin.at(0).pal_index(), 14U);
+}
+
+TEST_F(TilesetCompilerOverrideValidationTests, ManualDualDropReportsWarning)
+{
+    config_.global_frame_linking = FrameLinking::manual;
+
+    auto tileset = build_single_metatile_tileset("test_primary", rgba_green);
+    add_manual_anim(
+        tileset,
+        "anim",
+        rgba_red,
+        {AnimOverrideEntry{
+            .metatile_id = 0,
+            .layer = metatile::Layer::bottom,
+            .subtile = metatile::Subtile::northwest,
+            .frame_subtile = 0,
+            .pal_index = 0,
+            .h_flip = false,
+            .v_flip = false}});
+
+    auto compiler = make_compiler();
+    auto result = compiler->compile(tileset, false, nullptr);
+
+    // The metatile infers LayerType::normal, so dual-layerization drops the bottom layer this override targets.
+    ASSERT_TRUE(result.has_value()) << "Expected compile to succeed, got: " << join_error_chain(result);
+    ASSERT_TRUE(diag_->warning_tag_counts().contains("manual-dual-layer-drop"));
+    EXPECT_EQ(diag_->warning_tag_counts().at("manual-dual-layer-drop"), 1U);
+    EXPECT_TRUE(diag_->error_tag_counts().empty());
+}
+
+TEST_F(TilesetCompilerOverrideValidationTests, ManualBottomOverrideAppliesInTripleMode)
+{
+    config_.global_frame_linking = FrameLinking::manual;
+    config_.num_tiles_per_metatile = 12;
+
+    auto tileset = build_single_metatile_tileset("test_primary", rgba_green);
+    add_manual_anim(
+        tileset,
+        "anim",
+        rgba_red,
+        {AnimOverrideEntry{
+            .metatile_id = 0,
+            .layer = metatile::Layer::bottom,
+            .subtile = metatile::Subtile::northwest,
+            .frame_subtile = 0,
+            .pal_index = 0,
+            .h_flip = false,
+            .v_flip = false}});
+
+    auto compiler = make_compiler();
+    auto result = compiler->compile(tileset, false, nullptr);
+
+    // Triple mode keeps all layers, so the bottom/NW override survives at triple-layer index 0.
+    ASSERT_TRUE(result.has_value()) << "Expected compile to succeed, got: " << join_error_chain(result);
+    EXPECT_FALSE(diag_->warning_tag_counts().contains("manual-dual-layer-drop"));
+
+    const std::size_t tile_offset = result.value()->porytiles_component().anim_for_name("anim").params().tile_offset();
+    const auto &bin = result.value()->porymap_component().metatiles_bin();
+    ASSERT_FALSE(bin.empty());
+    EXPECT_EQ(bin.at(0).tile_index(), tile_offset);
+}
+
+TEST_F(TilesetCompilerOverrideValidationTests, PrimaryReferencesFrameSubtileOobReportsError)
+{
+    auto primary = build_compiled_primary_with_anim(
+        "test_primary", "flower", rgba_blue, config_.num_pals_in_primary, /*porymap_anim_tile_count=*/1);
+
+    auto secondary = build_empty_tileset("test_secondary");
+    secondary.porytiles_component().primary_anim_overrides(
+        {{"flower",
+          {AnimOverrideEntry{
+              .metatile_id = 0,
+              .layer = metatile::Layer::middle,
+              .subtile = metatile::Subtile::northwest,
+              .frame_subtile = 5,
+              .pal_index = 0,
+              .h_flip = false,
+              .v_flip = false}}}});
+
+    auto compiler = make_compiler();
+    auto result = compiler->compile(secondary, true, &primary);
+
+    ASSERT_TRUE(result.has_value()) << "Expected compile to succeed, got: " << join_error_chain(result);
+    ASSERT_TRUE(diag_->error_tag_counts().contains("primary-references-frame-subtile-oob"));
+    EXPECT_EQ(diag_->error_tag_counts().at("primary-references-frame-subtile-oob"), 1U);
+}
+
+TEST_F(TilesetCompilerOverrideValidationTests, PrimaryReferencesMetatileOobReportsError)
+{
+    auto primary = build_compiled_primary_with_anim(
+        "test_primary", "flower", rgba_blue, config_.num_pals_in_primary, /*porymap_anim_tile_count=*/1);
+
+    // A secondary with zero metatiles makes metatile_id 0 out of range.
+    auto secondary = build_empty_tileset("test_secondary");
+    secondary.porytiles_component().primary_anim_overrides(
+        {{"flower",
+          {AnimOverrideEntry{
+              .metatile_id = 0,
+              .layer = metatile::Layer::middle,
+              .subtile = metatile::Subtile::northwest,
+              .frame_subtile = 0,
+              .pal_index = 0,
+              .h_flip = false,
+              .v_flip = false}}}});
+
+    auto compiler = make_compiler();
+    auto result = compiler->compile(secondary, true, &primary);
+
+    ASSERT_TRUE(result.has_value()) << "Expected compile to succeed, got: " << join_error_chain(result);
+    ASSERT_TRUE(diag_->error_tag_counts().contains("primary-references-metatile-oob"));
+    EXPECT_EQ(diag_->error_tag_counts().at("primary-references-metatile-oob"), 1U);
+}
+
+TEST_F(TilesetCompilerOverrideValidationTests, PrimaryReferencesPalIndexUnencodableReportsError)
+{
+    auto primary = build_compiled_primary_with_anim(
+        "test_primary", "flower", rgba_blue, config_.num_pals_in_primary, /*porymap_anim_tile_count=*/1);
+
+    auto secondary = build_single_metatile_tileset("test_secondary", rgba_green);
+    secondary.porytiles_component().primary_anim_overrides(
+        {{"flower",
+          {AnimOverrideEntry{
+              .metatile_id = 0,
+              .layer = metatile::Layer::middle,
+              .subtile = metatile::Subtile::northwest,
+              .frame_subtile = 0,
+              .pal_index = 16,
+              .h_flip = false,
+              .v_flip = false}}}});
+
+    auto compiler = make_compiler();
+    auto result = compiler->compile(secondary, true, &primary);
+
+    ASSERT_TRUE(result.has_value()) << "Expected compile to succeed, got: " << join_error_chain(result);
+    ASSERT_TRUE(diag_->error_tag_counts().contains("primary-references-pal-index-oob"));
+    EXPECT_EQ(diag_->error_tag_counts().at("primary-references-pal-index-oob"), 1U);
+}
+
+TEST_F(TilesetCompilerOverrideValidationTests, PrimaryReferencesPalIndexUnconfiguredReportsWarning)
+{
+    auto primary = build_compiled_primary_with_anim(
+        "test_primary", "flower", rgba_blue, config_.num_pals_in_primary, /*porymap_anim_tile_count=*/1);
+
+    auto secondary = build_single_metatile_tileset("test_secondary", rgba_green);
+    secondary.porytiles_component().primary_anim_overrides(
+        {{"flower",
+          {AnimOverrideEntry{
+              .metatile_id = 0,
+              .layer = metatile::Layer::middle,
+              .subtile = metatile::Subtile::northwest,
+              .frame_subtile = 0,
+              .pal_index = 14,
+              .h_flip = false,
+              .v_flip = false}}}});
+
+    auto compiler = make_compiler();
+    auto result = compiler->compile(secondary, true, &primary);
+
+    ASSERT_TRUE(result.has_value()) << "Expected compile to succeed, got: " << join_error_chain(result);
+    ASSERT_TRUE(diag_->warning_tag_counts().contains("primary-references-pal-index-unused"));
+    EXPECT_EQ(diag_->warning_tag_counts().at("primary-references-pal-index-unused"), 1U);
+    EXPECT_TRUE(diag_->error_tag_counts().empty());
+}
+
+TEST_F(TilesetCompilerOverrideValidationTests, PrimaryReferencesDualDropReportsWarning)
+{
+    auto primary = build_compiled_primary_with_anim(
+        "test_primary", "flower", rgba_blue, config_.num_pals_in_primary, /*porymap_anim_tile_count=*/1);
+
+    auto secondary = build_single_metatile_tileset("test_secondary", rgba_green);
+    secondary.porytiles_component().primary_anim_overrides(
+        {{"flower",
+          {AnimOverrideEntry{
+              .metatile_id = 0,
+              .layer = metatile::Layer::bottom,
+              .subtile = metatile::Subtile::northwest,
+              .frame_subtile = 0,
+              .pal_index = 0,
+              .h_flip = false,
+              .v_flip = false}}}});
+
+    auto compiler = make_compiler();
+    auto result = compiler->compile(secondary, true, &primary);
+
+    // The secondary metatile infers LayerType::normal, so dual-layerization drops the bottom layer.
+    ASSERT_TRUE(result.has_value()) << "Expected compile to succeed, got: " << join_error_chain(result);
+    ASSERT_TRUE(diag_->warning_tag_counts().contains("primary-references-dual-layer-drop"));
+    EXPECT_EQ(diag_->warning_tag_counts().at("primary-references-dual-layer-drop"), 1U);
+    EXPECT_TRUE(diag_->error_tag_counts().empty());
 }

--- a/porytiles/tests/unit/domain/models/metatile_test.cpp
+++ b/porytiles/tests/unit/domain/models/metatile_test.cpp
@@ -345,3 +345,11 @@ TEST(MetatileTests, InferLayerTypeWithExtrinsicTransparency_Rgba32)
     const Rgba32 extrinsic{255, 0, 255, 255}; // Magenta as transparency key
     EXPECT_EQ(metatile.infer_layer_type(extrinsic), LayerType::split);
 }
+
+TEST(MetatileNamespaceTests, DroppedLayerForMatchesDualLayerizeBehavior)
+{
+    // normal renders middle/top, covered renders bottom/middle, split renders bottom/top.
+    EXPECT_EQ(dropped_layer_for(LayerType::normal), Layer::bottom);
+    EXPECT_EQ(dropped_layer_for(LayerType::covered), Layer::top);
+    EXPECT_EQ(dropped_layer_for(LayerType::split), Layer::middle);
+}


### PR DESCRIPTION
Fixed manual frame-linking overrides in `anim.json` aborting the compiler with an internal panic on an out-of-range `metatile_id`, and gave the manual and `primary_references` override paths consistent validation: both now report diagnostics for out-of-range `frame_subtile` and `metatile_id`, a `pal_index` that does not fit the hardware palette field, a `pal_index` past the configured palette count, and an override targeting a layer that dual-layer conversion drops. Also fixed a secondary that uses `primary_references` without defining any animations of its own having all of its overrides silently ignored.

Closes #330 