### PR TITLE
Auto-wrap support for stderr diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and to its issue too when one was filed
 
 - Added a fully configurable metatile attribute schema, replacing the hardcoded `BaseGame` (Emerald vs. FireRed/LeafGreen) system. Attribute layout, bit masks, and per-field enum sources are now handled by the config system, inferred from the project's own headers by default or declared explicitly via `metatile_attr_fields`, with per-tileset overrides for FRLG's alternate mask layout and layer type - [#341](https://github.com/grunt-lucas/porytiles/pull/341)
 
+- Added auto-wrap support for all diagnostic messages to simplify internal callsites. On the user side, diagnostics now dynamically wrap based on terminal width (as reported by ioctl). This can be overridden via the standard `COLUMNS` environment var. - [#342](https://github.com/grunt-lucas/porytiles/pull/342)
+
 ## [1.0.0] - 2026-06-05
 
 First stable release of Porytiles.

--- a/porytiles/include/porytiles/domain/algorithms/diagnostic_stencils.hpp
+++ b/porytiles/include/porytiles/domain/algorithms/diagnostic_stencils.hpp
@@ -324,12 +324,13 @@ template <std::size_t N>
     return lines;
 }
 
-/// @brief Builds truncated tile reference lines, displaying up to 8 entries 2-per-line with ellipsis.
+/// @brief Builds truncated tile reference lines, listing up to 8 entries comma-joined with ellipsis.
 ///
 /// @details
-/// Formats tile indices as metatile message headers, 2 per line, up to a maximum of 8 displayed entries. If there are
-/// more than 8, appends an "... and N more." line. The caller is responsible for providing any header line. This
-/// function only emits the tile reference listing.
+/// Formats tile indices as metatile message headers joined into a single comma-separated line, up to a maximum of 8
+/// displayed entries, letting terminal auto-wrap break the line as needed. If there are more than 8, appends an
+/// "... and N more." line as its own element. The caller is responsible for providing any header line. This function
+/// only emits the tile reference listing.
 ///
 /// @param format The TextFormatter for styling
 /// @param tile_indices The tile indices to display
@@ -338,35 +339,23 @@ template <std::size_t N>
 build_truncated_tile_ref_lines(const TextFormatter &format, const std::vector<std::size_t> &tile_indices)
 {
     constexpr std::size_t max_displayed_refs = 8;
-    constexpr std::size_t refs_per_line = 2;
 
     std::vector<std::string> lines;
     const std::size_t display_count = std::min(tile_indices.size(), max_displayed_refs);
-    std::string current_line;
-    std::size_t count_on_line = 0;
+    std::string joined;
     for (std::size_t i = 0; i < display_count; i++) {
-        if (count_on_line > 0) {
-            current_line += ", ";
+        if (i > 0) {
+            joined += ", ";
         }
         auto [mt_index, layer, subtile] = metatile::from_tile_index(tile_indices.at(i));
-        current_line += "secondary " + metatile::message_header(format, mt_index, layer, subtile);
-        count_on_line++;
-        if (count_on_line == refs_per_line) {
-            lines.emplace_back(current_line);
-            current_line.clear();
-            count_on_line = 0;
-        }
+        joined += "secondary " + metatile::message_header(format, mt_index, layer, subtile);
+    }
+    if (!joined.empty()) {
+        lines.emplace_back(joined);
     }
     if (tile_indices.size() > max_displayed_refs) {
-        if (!current_line.empty()) {
-            lines.emplace_back(current_line);
-            current_line.clear();
-        }
         lines.emplace_back(
             format.format("... and {} more.", FormatParam{tile_indices.size() - max_displayed_refs, Style::bold}));
-    }
-    else if (!current_line.empty()) {
-        lines.emplace_back(current_line);
     }
     return lines;
 }

--- a/porytiles/include/porytiles/domain/algorithms/tileset_compile_validators.hpp
+++ b/porytiles/include/porytiles/domain/algorithms/tileset_compile_validators.hpp
@@ -1357,8 +1357,8 @@ inline void report_color_counts(
                 services.diag.error_note(
                     "transparent-key-frame",
                     std::vector<std::string>{
-                        "Key frame tiles cannot be fully transparent because they would be",
-                        "indistinguishable from the actual transparent tile on the layer PNGs."});
+                        "Key frame tiles cannot be fully transparent because they would be indistinguishable "
+                        "from the actual transparent tile on the layer PNGs."});
             }
         }
     }
@@ -1412,8 +1412,9 @@ inline void report_color_counts(
                     "   - anim '{}' subtile {}", FormatParam{anim_name, Style::bold}, FormatParam{tile_idx}));
             }
             note_lines.emplace_back("");
-            note_lines.emplace_back("Each key frame tile must be unique so that Porytiles can");
-            note_lines.emplace_back("identify which animation a tile belongs to at runtime.");
+            note_lines.emplace_back(
+                "Each key frame tile must be unique so that Porytiles can identify which "
+                "animation a tile belongs to at runtime.");
             services.diag.error_note("duplicate-key-frame", note_lines);
         }
     }
@@ -1496,9 +1497,10 @@ inline void report_color_counts(
                     extrinsic_transparency);
 
                 std::vector<std::string> note_lines;
-                note_lines.emplace_back("The composite frame aggregates all colors across all animation frames");
-                note_lines.emplace_back("for each tile position. Since the palette index is fixed for the");
-                note_lines.emplace_back("entire animation lifecycle, each composite tile cannot exceed 15 colors.");
+                note_lines.emplace_back(
+                    "The composite frame aggregates all colors across all animation frames for each tile position. "
+                    "Since the palette index is fixed for the entire animation lifecycle, each composite tile cannot "
+                    "exceed 15 colors.");
                 services.diag.error_note("composite-color-count-violation", note_lines);
 
                 // Print all frame tiles at this position to show what's contributing colors

--- a/porytiles/include/porytiles/infra/config/metatiles_header_provider.hpp
+++ b/porytiles/include/porytiles/infra/config/metatiles_header_provider.hpp
@@ -27,6 +27,10 @@ namespace porytiles {
 ///
 /// The file is read lazily on first access and the result is cached.
 class MetatilesHeaderProvider final {
+    // TODO: this class is an oddball. It's in infra/config with a *Provider moniker, but it's not actually a
+    // ConfigProvider. It's used by MetatileAttributeConfigProvider, which is a real provider. It's also used by
+    // TilesetAttrSchemaResolver. So this class really feels like in belongs in infra/services, except it has a
+    // LayerValue return type on detect, which makes in an infra/config candidate. I think this is a smell.
   public:
     /// @brief Constructs a MetatilesHeaderProvider.
     ///

--- a/porytiles/include/porytiles/utilities/text/terminal_width.hpp
+++ b/porytiles/include/porytiles/utilities/text/terminal_width.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <cstddef>
+
+namespace porytiles {
+
+/// @brief Resolves the column width to use for wrapping diagnostic output on @p fd.
+///
+/// @details
+/// Consults sources in priority order so callers get the width the user actually wants:
+///
+/// 1. The `COLUMNS` environment variable, when set to a positive integer. This lets users and tests override detection
+///    regardless of whether @p fd is a terminal.
+/// 2. `ioctl(fd, TIOCGWINSZ)`, when @p fd is a terminal reporting a non-zero column count.
+/// 3. The @p fallback, used when neither source yields a usable width (for example when output is redirected).
+///
+/// The resolution is intentionally kept as a single free function so a future config layer can decide the width (fixed
+/// value, disabled, or auto-detected) and hand the result to the diagnostics printer without the printer needing to
+/// know how it was chosen.
+///
+/// @param fd The file descriptor whose terminal to measure (typically STDERR_FILENO)
+/// @param fallback The width to return when no terminal width can be determined
+/// @return The resolved column width
+[[nodiscard]] std::size_t resolve_terminal_width(int fd, std::size_t fallback = 80);
+
+} // namespace porytiles

--- a/porytiles/include/porytiles/utilities/text/text_formatter.hpp
+++ b/porytiles/include/porytiles/utilities/text/text_formatter.hpp
@@ -464,11 +464,7 @@ class FormatParam {
 /// - style(): Apply Style flags to individual text strings
 /// - format(): Substitute styled FormatParams into format strings using fmtlib syntax
 ///
-/// Implementations:
-/// - PlainTextFormatter: Returns text unchanged, stripping all styles (for non-TTY/files)
-/// - AnsiStyledTextFormatter: Applies ANSI escape codes for terminal colors (for TTY)
-///
-/// This class integrates with the error reporting system through FormattableError and UserDiagnostics to provide
+/// The class integrates with the error reporting system through FormattableError and UserDiagnostics to provide
 /// adaptive styling for diagnostic messages.
 class TextFormatter {
   public:

--- a/porytiles/include/porytiles/utilities/text/text_wrap.hpp
+++ b/porytiles/include/porytiles/utilities/text/text_wrap.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <cstddef>
+#include <string>
+#include <vector>
+
+namespace porytiles {
+
+/// @brief Word-wraps a single logical line to a visible column width, preserving ANSI styling.
+///
+/// @details
+/// Breaks @p line into as many physical lines as needed so that each one occupies at most @p width visible columns.
+/// The wrapping is ANSI-aware in two ways:
+///
+/// - **Zero-width escapes**: ANSI SGR sequences (e.g. `\033[1m`, `\033[38;2;r;g;bm`, `\033[0m`) do not count toward the
+///   visible width, and the function never breaks in the middle of one.
+/// - **Style carry-over**: when a break lands inside an open style span, the physical line is closed with a reset and
+///   the next physical line re-opens the still-active styles, so color never bleeds into the gutter or drops on
+///   continuation lines.
+///
+/// Breaks prefer space boundaries; the single space at a break point is consumed rather than rendered. A word longer
+/// than @p width on its own is hard-broken at the column limit. UTF-8 sequences are treated as one visible column each
+/// and are never split.
+///
+/// @param line The logical line to wrap (may contain ANSI escape sequences)
+/// @param width The maximum visible columns per physical line; a value of 0 disables wrapping
+/// @return The physical lines; a single-element vector containing @p line unchanged when @p width is 0
+[[nodiscard]] std::vector<std::string> wrap_ansi_line(const std::string &line, std::size_t width);
+
+} // namespace porytiles

--- a/porytiles/include/porytiles/xcut/diagnostics/stderr_styled_user_diagnostics.hpp
+++ b/porytiles/include/porytiles/xcut/diagnostics/stderr_styled_user_diagnostics.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <string>
 #include <vector>
 
@@ -25,9 +26,18 @@ namespace porytiles {
 /// guidelines to aid reading
 /// - **Error Chain Visualization**: Fatal errors are displayed with tree-like formatting using Unicode box-drawing
 /// characters to show error hierarchy
+/// - **Auto-Wrap**: Message bodies are wrapped to a configured column width so long lines fit the user's terminal,
+/// while any explicit line breaks the caller supplied (each element of the lines vector) are still honored
 class StderrStyledUserDiagnostics final : public UserDiagnostics {
   public:
-    explicit StderrStyledUserDiagnostics(const gsl::not_null<TextFormatter *> format) : UserDiagnostics{format} {}
+    /// @brief Constructs the printer, optionally enabling auto-wrap at @p wrap_width columns.
+    ///
+    /// @param format The text formatter used to style output
+    /// @param wrap_width The terminal column width to wrap message bodies to; 0 disables wrapping
+    explicit StderrStyledUserDiagnostics(const gsl::not_null<TextFormatter *> format, const std::size_t wrap_width = 0)
+        : UserDiagnostics{format}, wrap_width_{wrap_width}
+    {
+    }
 
     /// @brief Display a multi-line tagged informational remark to stderr.
     ///
@@ -123,6 +133,9 @@ class StderrStyledUserDiagnostics final : public UserDiagnostics {
 
   private:
     void emit_note_impl(const std::string &tag, const std::vector<std::string> &lines) const;
+
+    /// @brief Column width for wrapping message bodies; 0 disables wrapping.
+    std::size_t wrap_width_;
 };
 
 } // namespace porytiles

--- a/porytiles/lib/domain/services/metatile_attr_schema_loader.cpp
+++ b/porytiles/lib/domain/services/metatile_attr_schema_loader.cpp
@@ -45,9 +45,8 @@ namespace {
         return FormattableError{std::vector<std::string>{
             "No metatile attribute fields are configured.",
             "Porytiles could not infer a field layout and none was provided.",
-            "Add a metatile_attr_fields list to your Porytiles config,",
-            "or make sure the base game exposes its attribute masks "
-            "(a METATILE_ATTR_*_MASK define or an sMetatileAttrMasks table)."}};
+            "Add a metatile_attr_fields list to your Porytiles config, or make sure the base game exposes "
+            "its attribute masks (a METATILE_ATTR_*_MASK define or an sMetatileAttrMasks table)."}};
     }
 
     // A baseline name must be unique so overrides and the schema can address fields unambiguously.
@@ -165,8 +164,8 @@ ChainableResult<ResolvedTilesetAttrSchema> resolve_tileset_attr_schema(
         if (frlg) {
             return FormattableError{std::vector<std::string>{
                 "The FRLG attribute layout has no fields: none of the configured fields define a frlg_mask.",
-                "Add a frlg_mask to at least one field,",
-                "or set use_frlg_alternate_masks: never to use the primary masks."}};
+                "Add a frlg_mask to at least one field, or set use_frlg_alternate_masks: never to use the "
+                "primary masks."}};
         }
         return FormattableError{std::vector<std::string>{
             "The primary attribute layout has no fields: none of the configured fields define a mask.",
@@ -200,19 +199,16 @@ ChainableResult<ResolvedTilesetAttrSchema> resolve_tileset_attr_schema(
         // 'const uN *metatileAttributes'). A mask that needs a wider word contradicts that hard fact, so reject it
         // instead of silently widening, which would emit a mismatched declaration and corrupt the packed attributes on
         // the next read.
-        return FormattableError{std::vector<std::string>{
-            format->format(
-                "{} needs a {}-byte attribute word, but 'src/data/tilesets/metatiles.h' declares {}-byte attributes.",
-                FormatParam{widest_source, Style::bold},
-                FormatParam{mask_bytes, Style::bold},
-                FormatParam{detected_attr_bytes, Style::bold}),
-            "The attribute width is fixed by the base game and shared across all tilesets,",
-            "so Porytiles cannot widen it to fit this mask.",
-            format->format("Narrow the mask to fit {} bytes,", FormatParam{detected_attr_bytes, Style::bold}),
-            format->format(
-                "or change the gMetatileAttributes_* declarations in metatiles.h to 'const u{}'",
-                FormatParam{mask_bytes * 8, Style::bold}),
-            "if the base game really uses a wider attribute word."}};
+        return FormattableError{
+            "{} needs a {}-byte attribute word, but 'src/data/tilesets/metatiles.h' declares {}-byte attributes. The "
+            "attribute width is fixed by the base game and shared across all tilesets, so Porytiles cannot widen it to "
+            "fit this mask. Narrow the mask to fit {} bytes,  or change the gMetatileAttributes_* declarations in "
+            "metatiles.h to 'const u{}' if the base game really uses a wider attribute word.",
+            FormatParam{widest_source, Style::bold},
+            FormatParam{mask_bytes, Style::bold},
+            FormatParam{detected_attr_bytes, Style::bold},
+            FormatParam{detected_attr_bytes, Style::bold},
+            FormatParam{mask_bytes * 8, Style::bold}};
     }
     else {
         // Primary layout where the detected width covers the masks (authoritative) or was only a guessed default. In

--- a/porytiles/lib/domain/services/tileset_compiler.cpp
+++ b/porytiles/lib/domain/services/tileset_compiler.cpp
@@ -1808,8 +1808,8 @@ ChainableResult<void> CompilerTask::pipeline_helper_register_animations()
                                 FormatParam{i},
                                 FormatParam{abs_tile_index}),
                             "Cannot determine the correct palette index for cross-tileset linking.",
-                            "Recompile the primary tileset, or verify that all primary animation subtiles",
-                            "are used in at least one primary metatile."}};
+                            "Recompile the primary tileset, or verify that all primary animation subtiles are used "
+                            "in at least one primary metatile."}};
                     }
                 }
             }

--- a/porytiles/lib/domain/services/tileset_compiler.cpp
+++ b/porytiles/lib/domain/services/tileset_compiler.cpp
@@ -486,7 +486,8 @@ ChainableResult<void> CompilerTask::pipeline_step_process_porytiles_input()
             tileset_.porytiles_component().middle(),
             tileset_.porytiles_component().top()),
         void,
-        "failed to metatileize input layer images for " + tileset_.name());
+        format_.format(
+            "Failed to metatileize input layer images for tileset '{}'.", FormatParam{tileset_.name(), Style::bold}));
     porytiles_metatiles_ = std::move(metatiles);
 
     // Decompose Porytiles metatiles and generate canonical versions
@@ -506,7 +507,9 @@ ChainableResult<void> CompilerTask::pipeline_step_process_porymap_input()
         tilemap_entries,
         layer_mode_converter.triple_layerize(tileset_.porymap_component()),
         void,
-        std::format("Failed to triple-layerize Porymap component for tileset '{}'.", tileset_.name()));
+        format_.format(
+            "Failed to triple-layerize Porymap component for tileset '{}'.",
+            FormatParam{tileset_.name(), Style::bold}));
     porymap_tilemap_entries_ = std::move(tilemap_entries);
 
     PT_TRY_ASSIGN_CHAIN_ERR(
@@ -514,7 +517,8 @@ ChainableResult<void> CompilerTask::pipeline_step_process_porymap_input()
         metatile_decompiler.decompile_metatiles(
             porymap_tilemap_entries_, tileset_.porymap_component().tiles_png(), tileset_.porymap_component().pals()),
         void,
-        std::format("Failed to decompile Porymap component for tileset '{}'.", tileset_.name()));
+        format_.format(
+            "Failed to decompile Porymap component for tileset '{}'.", FormatParam{tileset_.name(), Style::bold}));
     porymap_metatiles_ = std::move(metatiles);
 
     // We don't need to run any validation (including size validation) on porymap_metatiles here. We're going to
@@ -539,13 +543,11 @@ ChainableResult<void> CompilerTask::pipeline_step_validate_input()
     if (is_secondary() && tiles_edit_mode_ != ArtifactEditMode::optimize) {
         std::vector<std::string> err_msg{};
         err_msg.emplace_back(format_.format(
-            "Secondary compilation of tileset '{}' does not yet support tiles edit mode '{}'.",
+            "Secondary compilation of tileset '{}' does not yet support tiles edit mode '{}'. For now, only '{}' is "
+            "supported for secondary tilesets. Support for '{}' and '{}' is planned for a future update.",
             FormatParam{tileset_.name(), Style::bold},
-            FormatParam{to_string(tiles_edit_mode_.value()), Style::bold}));
-        err_msg.emplace_back(format_.format(
-            "For now, only '{}' is supported for secondary tilesets.", FormatParam{"optimize", Style::bold}));
-        err_msg.emplace_back(format_.format(
-            "Support for '{}' and '{}' is planned for a future update.",
+            FormatParam{to_string(tiles_edit_mode_.value()), Style::bold},
+            FormatParam{"optimize", Style::bold},
             FormatParam{"locked", Style::bold},
             FormatParam{"patch", Style::bold}));
         err_msg.append_range(format_config_note_with_separator(format_, tiles_edit_mode_));
@@ -555,13 +557,11 @@ ChainableResult<void> CompilerTask::pipeline_step_validate_input()
     if (is_secondary() && pals_edit_mode_ != ArtifactEditMode::optimize) {
         std::vector<std::string> err_msg{};
         err_msg.emplace_back(format_.format(
-            "Secondary compilation of tileset '{}' does not yet support pals edit mode '{}'.",
+            "Secondary compilation of tileset '{}' does not yet support pals edit mode '{}'. For now, only '{}' is "
+            "supported for secondary tilesets. Support for '{}' and '{}' is planned for a future update.",
             FormatParam{tileset_.name(), Style::bold},
-            FormatParam{to_string(pals_edit_mode_.value()), Style::bold}));
-        err_msg.emplace_back(format_.format(
-            "For now, only '{}' is supported for secondary tilesets.", FormatParam{"optimize", Style::bold}));
-        err_msg.emplace_back(format_.format(
-            "Support for '{}' and '{}' is planned for a future update.",
+            FormatParam{to_string(pals_edit_mode_.value()), Style::bold},
+            FormatParam{"optimize", Style::bold},
             FormatParam{"locked", Style::bold},
             FormatParam{"patch", Style::bold}));
         err_msg.append_range(format_config_note_with_separator(format_, pals_edit_mode_));
@@ -581,13 +581,12 @@ ChainableResult<void> CompilerTask::pipeline_step_validate_input()
     if (pals_edit_mode_ == ArtifactEditMode::optimize && tiles_edit_mode_ == ArtifactEditMode::locked) {
         std::vector<std::string> err_msg{};
         err_msg.emplace_back(format_.format(
-            "Tileset '{}' uses palettes edit mode '{}' with tiles edit mode '{}', which is not a valid combination.",
+            "Tileset '{}' uses palettes edit mode '{}' with tiles edit mode '{}', which is not a valid combination. "
+            "Tiles are fundamentally dependent on palettes, so optimizing palettes while keeping tiles locked is "
+            "not coherent.",
             FormatParam{tileset_.name(), Style::bold},
             FormatParam{"optimize", Style::bold},
             FormatParam{"locked", Style::bold}));
-        err_msg.emplace_back(
-            "Tiles are fundamentally dependent on palettes, so optimizing palettes while keeping "
-            "tiles locked is not coherent.");
         err_msg.append_range(format_config_note(format_, pals_edit_mode_));
         err_msg.append_range(format_config_note_with_separator(format_, tiles_edit_mode_));
         return FormattableError{err_msg};
@@ -1181,7 +1180,7 @@ ChainableResult<void> CompilerTask::pipeline_helper_run_pal_packing()
         color_index_map,
         pipeline_helper_build_color_index_map(pal_hints_.value(), color_count_limit),
         void,
-        std::format("Failed to build color index map for tileset '{}'.", tileset_.name()));
+        format_.format("Failed to build color index map for tileset '{}'.", FormatParam{tileset_.name(), Style::bold}));
 
     PT_UNWRAP_TILESET_CONFIG_REF(config_, packing_strategy, tileset_.name(), void);
     PT_UNWRAP_TILESET_CONFIG_REF(config_, packing_strategy_params, tileset_.name(), void);

--- a/porytiles/lib/utilities/text/terminal_width.cpp
+++ b/porytiles/lib/utilities/text/terminal_width.cpp
@@ -1,0 +1,59 @@
+#include "porytiles/utilities/text/terminal_width.hpp"
+
+#include <cstddef>
+#include <cstdlib>
+#include <optional>
+#include <string>
+
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+namespace {
+
+/// @brief Parses the COLUMNS environment variable into a positive width, if it is set and valid.
+std::optional<std::size_t> width_from_columns_env()
+{
+    const char *columns = std::getenv("COLUMNS");
+    if (columns == nullptr) {
+        return std::nullopt;
+    }
+    try {
+        std::size_t consumed = 0;
+        const long value = std::stol(std::string{columns}, &consumed);
+        // Require the whole value to parse and to be positive; ignore junk like "abc" or "80x".
+        if (consumed == std::string{columns}.size() && value > 0) {
+            return static_cast<std::size_t>(value);
+        }
+    }
+    catch (...) {
+        // Fall through to the next source on any parse failure.
+    }
+    return std::nullopt;
+}
+
+/// @brief Queries the terminal column count for @p fd via ioctl, if it is a terminal reporting a width.
+std::optional<std::size_t> width_from_ioctl(const int fd)
+{
+    struct winsize ws{};
+    if (ioctl(fd, TIOCGWINSZ, &ws) == 0 && ws.ws_col > 0) {
+        return static_cast<std::size_t>(ws.ws_col);
+    }
+    return std::nullopt;
+}
+
+} // namespace
+
+namespace porytiles {
+
+std::size_t resolve_terminal_width(const int fd, const std::size_t fallback)
+{
+    if (const auto from_env = width_from_columns_env()) {
+        return *from_env;
+    }
+    if (const auto from_ioctl = width_from_ioctl(fd)) {
+        return *from_ioctl;
+    }
+    return fallback;
+}
+
+} // namespace porytiles

--- a/porytiles/lib/utilities/text/text_wrap.cpp
+++ b/porytiles/lib/utilities/text/text_wrap.cpp
@@ -1,0 +1,187 @@
+#include "porytiles/utilities/text/text_wrap.hpp"
+
+#include <algorithm>
+#include <cstddef>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+
+using namespace porytiles;
+
+const std::string ansi_reset = "\033[0m";
+
+/// @brief One visible glyph plus the ANSI escape sequences that immediately precede it.
+struct Cell {
+    std::string prefix; ///< ANSI escape sequences emitted just before the glyph (may be empty)
+    std::string glyph;  ///< A single visible unit: one UTF-8 code point, counted as one column
+    bool is_space;      ///< True when the glyph is an ASCII space, marking a break opportunity
+};
+
+/// @brief Advances past a CSI escape sequence starting at @p pos, returning its raw text.
+std::string consume_escape(const std::string &line, std::size_t &pos)
+{
+    const std::size_t start = pos;
+    pos += 2; // skip the ESC and '['
+    // CSI parameters/intermediates run until a final byte in the 0x40-0x7E range.
+    while (pos < line.size() &&
+           (static_cast<unsigned char>(line[pos]) < 0x40 || static_cast<unsigned char>(line[pos]) > 0x7E)) {
+        ++pos;
+    }
+    if (pos < line.size()) {
+        ++pos; // include the final byte
+    }
+    return line.substr(start, pos - start);
+}
+
+/// @brief Advances past one UTF-8 code point starting at @p pos, returning its raw bytes.
+std::string consume_codepoint(const std::string &line, std::size_t &pos)
+{
+    const std::size_t start = pos;
+    const auto lead = static_cast<unsigned char>(line[pos]);
+    std::size_t len = 1;
+    if ((lead & 0x80U) != 0) {
+        if ((lead & 0xE0U) == 0xC0U) {
+            len = 2;
+        }
+        else if ((lead & 0xF0U) == 0xE0U) {
+            len = 3;
+        }
+        else if ((lead & 0xF8U) == 0xF0U) {
+            len = 4;
+        }
+    }
+    len = std::min(len, line.size() - pos);
+    pos += len;
+    return line.substr(start, len);
+}
+
+/// @brief Splits a line into visible glyph cells, capturing any trailing escapes with no following glyph.
+std::vector<Cell> tokenize(const std::string &line, std::string &trailing_out)
+{
+    std::vector<Cell> cells;
+    std::string pending_prefix;
+    std::size_t pos = 0;
+    while (pos < line.size()) {
+        if (static_cast<unsigned char>(line[pos]) == 0x1B && pos + 1 < line.size() && line[pos + 1] == '[') {
+            pending_prefix += consume_escape(line, pos);
+        }
+        else {
+            std::string glyph = consume_codepoint(line, pos);
+            const bool is_space = glyph == " ";
+            cells.push_back(Cell{std::move(pending_prefix), std::move(glyph), is_space});
+            pending_prefix.clear();
+        }
+    }
+    trailing_out = pending_prefix;
+    return cells;
+}
+
+/// @brief Folds an escape-code prefix into the active SGR state, clearing it on a full reset.
+void apply_sgr(std::string &active, const std::string &prefix)
+{
+    std::size_t pos = 0;
+    while (pos < prefix.size()) {
+        const std::size_t start = pos;
+        std::string seq = consume_escape(prefix, pos);
+        if (seq == ansi_reset || seq == "\033[m") {
+            active.clear();
+        }
+        else {
+            active += seq;
+        }
+    }
+}
+
+} // namespace
+
+namespace porytiles {
+
+std::vector<std::string> wrap_ansi_line(const std::string &line, const std::size_t width)
+{
+    if (width == 0) {
+        return {line};
+    }
+
+    std::string trailing;
+    const std::vector<Cell> cells = tokenize(line, trailing);
+    if (cells.empty()) {
+        return {line};
+    }
+
+    // active_entering[i] is the SGR state in effect just before cell i's own prefix, i.e. the styling a wrapped
+    // continuation line must re-open when it starts at cell i. active_entering[cells.size()] is the state after the
+    // final cell, used to decide whether a line needs a trailing reset.
+    std::vector<std::string> active_entering(cells.size() + 1);
+    for (std::size_t i = 0; i < cells.size(); ++i) {
+        active_entering[i + 1] = active_entering[i];
+        apply_sgr(active_entering[i + 1], cells[i].prefix);
+    }
+
+    // First pass: choose the [start, end) cell ranges for each physical line, breaking at spaces where possible.
+    std::vector<std::pair<std::size_t, std::size_t>> ranges;
+    std::size_t i = 0;
+    while (i < cells.size()) {
+        const std::size_t line_start = i;
+        std::size_t visible = 0;
+        std::size_t last_space = cells.size(); // sentinel: no break opportunity seen yet
+        std::size_t j = i;
+        while (j < cells.size() && visible < width) {
+            if (cells[j].is_space) {
+                last_space = j;
+            }
+            ++visible;
+            ++j;
+        }
+        if (j == cells.size()) {
+            ranges.emplace_back(line_start, cells.size());
+            break;
+        }
+        if (cells[j].is_space) {
+            // The break lands exactly on a space: end the line here and swallow the run of spaces.
+            ranges.emplace_back(line_start, j);
+            while (j < cells.size() && cells[j].is_space) {
+                ++j;
+            }
+            i = j;
+        }
+        else if (last_space != cells.size() && last_space > line_start) {
+            // Break at the last space that fit on the line, swallowing that single space.
+            ranges.emplace_back(line_start, last_space);
+            i = last_space + 1;
+        }
+        else {
+            // No usable space boundary (an over-long word): hard-break at the column limit.
+            ranges.emplace_back(line_start, j);
+            i = j;
+        }
+    }
+
+    // Second pass: render each range, re-opening inherited style and closing any style left open.
+    std::vector<std::string> result;
+    result.reserve(ranges.size());
+    for (std::size_t r = 0; r < ranges.size(); ++r) {
+        const auto [start, end] = ranges[r];
+        std::string rendered = active_entering[start];
+        for (std::size_t k = start; k < end; ++k) {
+            rendered += cells[k].prefix;
+            rendered += cells[k].glyph;
+        }
+        const bool is_last = r + 1 == ranges.size();
+        if (is_last) {
+            rendered += trailing;
+        }
+        std::string active_at_end = active_entering[end];
+        if (is_last) {
+            apply_sgr(active_at_end, trailing);
+        }
+        if (!active_at_end.empty()) {
+            rendered += ansi_reset;
+        }
+        result.push_back(std::move(rendered));
+    }
+    return result;
+}
+
+} // namespace porytiles

--- a/porytiles/lib/xcut/diagnostics/stderr_styled_user_diagnostics.cpp
+++ b/porytiles/lib/xcut/diagnostics/stderr_styled_user_diagnostics.cpp
@@ -1,12 +1,41 @@
 #include "porytiles/xcut/diagnostics/stderr_styled_user_diagnostics.hpp"
 
+#include <cstddef>
 #include <iostream>
-#include <ranges>
 #include <string>
 #include <vector>
 
 #include "porytiles/utilities/panic/panic.hpp"
 #include "porytiles/utilities/text/text_formatter.hpp"
+#include "porytiles/utilities/text/text_wrap.hpp"
+
+namespace {
+
+using namespace porytiles;
+
+// The gutter "│ " that prefixes every body line occupies two visible columns.
+constexpr std::size_t gutter_columns = 2;
+
+/// @brief Prints the message body lines under a "│ " gutter, auto-wrapping each to the configured width.
+///
+/// @details
+/// Each element of @p lines is a caller-supplied logical line (an explicit line break the caller wanted preserved).
+/// It is further wrapped to fit @p wrap_width, so a long logical line spills onto extra gutter-prefixed physical lines
+/// instead of overrunning the terminal. A @p wrap_width of 0 prints the lines unwrapped.
+void print_body(
+    const TextFormatter &fmt, const Style style, const std::vector<std::string> &lines, const std::size_t wrap_width)
+{
+    const std::size_t body_width =
+        wrap_width == 0 ? 0 : (wrap_width > gutter_columns ? wrap_width - gutter_columns : 1);
+    const std::string gutter = fmt.style("│", style);
+    for (const auto &logical : lines) {
+        for (const auto &physical : wrap_ansi_line(logical, body_width)) {
+            std::cerr << gutter << " " << physical << std::endl;
+        }
+    }
+}
+
+} // namespace
 
 namespace porytiles {
 
@@ -19,9 +48,7 @@ void StderrStyledUserDiagnostics::remark(const std::string &tag, const std::vect
               << formatter().style("[", Style::bold | Style::blue) << formatter().style(tag, Style::bold | Style::blue)
               << formatter().style("]:", Style::bold | Style::blue) << std::endl;
     std::cerr << formatter().style("│", Style::bold | Style::blue) << std::endl;
-    for (const auto &line : lines) {
-        std::cerr << formatter().style("│", Style::bold | Style::blue) << " " << line << std::endl;
-    }
+    print_body(formatter(), Style::bold | Style::blue, lines, wrap_width_);
     std::cerr << formatter().style("│", Style::bold | Style::blue) << std::endl;
 }
 
@@ -35,9 +62,7 @@ void StderrStyledUserDiagnostics::warning(const std::string &tag, const std::vec
               << formatter().style(tag, Style::bold | Style::magenta)
               << formatter().style("]:", Style::bold | Style::magenta) << std::endl;
     std::cerr << formatter().style("│", Style::bold | Style::magenta) << std::endl;
-    for (const auto &line : lines) {
-        std::cerr << formatter().style("│", Style::bold | Style::magenta) << " " << line << std::endl;
-    }
+    print_body(formatter(), Style::bold | Style::magenta, lines, wrap_width_);
     std::cerr << formatter().style("│", Style::bold | Style::magenta) << std::endl;
 }
 
@@ -50,9 +75,7 @@ void StderrStyledUserDiagnostics::error(const std::string &tag, const std::vecto
               << formatter().style("[", Style::bold | Style::red) << formatter().style(tag, Style::bold | Style::red)
               << formatter().style("]:", Style::bold | Style::red) << std::endl;
     std::cerr << formatter().style("│", Style::bold | Style::red) << std::endl;
-    for (const auto &line : lines) {
-        std::cerr << formatter().style("│", Style::bold | Style::red) << " " << line << std::endl;
-    }
+    print_body(formatter(), Style::bold | Style::red, lines, wrap_width_);
     std::cerr << formatter().style("│", Style::bold | Style::red) << std::endl;
 }
 
@@ -62,9 +85,7 @@ void StderrStyledUserDiagnostics::emit_fatal_proximate(const Error &err) const
     if (!lines.empty()) {
         std::cerr << formatter().style("fatal:", Style::bold | Style::red) << std::endl;
         std::cerr << formatter().style("│", Style::bold | Style::red) << std::endl;
-        for (const auto &line : lines) {
-            std::cerr << formatter().style("│", Style::bold | Style::red) << " " << line << std::endl;
-        }
+        print_body(formatter(), Style::bold | Style::red, lines, wrap_width_);
         std::cerr << formatter().style("│", Style::bold | Style::red) << std::endl;
     }
 }
@@ -76,10 +97,7 @@ void StderrStyledUserDiagnostics::emit_fatal_step(const Error &err) const
 
     auto lines = err.details(formatter());
     if (!lines.empty()) {
-        std::cerr << formatter().style("│", Style::bold | Style::red) << " " << lines.at(0) << std::endl;
-        for (const auto &line : std::ranges::views::drop(lines, 1)) {
-            std::cerr << formatter().style("│", Style::bold | Style::red) << " " << line << std::endl;
-        }
+        print_body(formatter(), Style::bold | Style::red, lines, wrap_width_);
     }
     std::cerr << formatter().style("│", Style::bold | Style::red) << std::endl;
 }
@@ -91,10 +109,7 @@ void StderrStyledUserDiagnostics::emit_fatal_root(const Error &err) const
 
     auto lines = err.details(formatter());
     if (!lines.empty()) {
-        std::cerr << formatter().style("│", Style::bold | Style::red) << " " << lines.at(0) << std::endl;
-        for (const auto &line : std::ranges::views::drop(lines, 1)) {
-            std::cerr << formatter().style("│", Style::bold | Style::red) << " " << line << std::endl;
-        }
+        print_body(formatter(), Style::bold | Style::red, lines, wrap_width_);
     }
     std::cerr << formatter().style("│", Style::bold | Style::red) << std::endl;
 }
@@ -123,9 +138,7 @@ void StderrStyledUserDiagnostics::emit_note_impl(const std::string &tag, const s
               << formatter().style("[", Style::bold | Style::cyan) << formatter().style(tag, Style::bold | Style::cyan)
               << formatter().style("]:", Style::bold | Style::cyan) << std::endl;
     std::cerr << formatter().style("│", Style::bold | Style::cyan) << std::endl;
-    for (const auto &line : lines) {
-        std::cerr << formatter().style("│", Style::bold | Style::cyan) << " " << line << std::endl;
-    }
+    print_body(formatter(), Style::bold | Style::cyan, lines, wrap_width_);
     std::cerr << formatter().style("│", Style::bold | Style::cyan) << std::endl;
 }
 

--- a/porytiles/tests/unit/utilities/text/terminal_width_test.cpp
+++ b/porytiles/tests/unit/utilities/text/terminal_width_test.cpp
@@ -1,0 +1,80 @@
+#include "gtest/gtest.h"
+
+#include <cstdlib>
+#include <string>
+
+#include "porytiles/utilities/text/terminal_width.hpp"
+
+using namespace porytiles;
+
+namespace {
+
+/// @brief Restores (or clears) the COLUMNS environment variable when the test scope exits.
+class ColumnsEnvGuard {
+  public:
+    ColumnsEnvGuard()
+    {
+        const char *existing = std::getenv("COLUMNS");
+        if (existing != nullptr) {
+            had_value_ = true;
+            saved_ = existing;
+        }
+    }
+
+    ColumnsEnvGuard(const ColumnsEnvGuard &) = delete;
+    ColumnsEnvGuard &operator=(const ColumnsEnvGuard &) = delete;
+    ColumnsEnvGuard(ColumnsEnvGuard &&) = delete;
+    ColumnsEnvGuard &operator=(ColumnsEnvGuard &&) = delete;
+
+    ~ColumnsEnvGuard()
+    {
+        if (had_value_) {
+            setenv("COLUMNS", saved_.c_str(), 1);
+        }
+        else {
+            unsetenv("COLUMNS");
+        }
+    }
+
+  private:
+    bool had_value_ = false;
+    std::string saved_;
+};
+
+} // namespace
+
+TEST(TerminalWidthTests, ColumnsEnvOverridesEverything)
+{
+    ColumnsEnvGuard guard;
+    setenv("COLUMNS", "123", 1);
+    // fd -1 is not a terminal, so only the env var can supply the width.
+    EXPECT_EQ(resolve_terminal_width(-1, 80), 123U);
+}
+
+TEST(TerminalWidthTests, FallbackWhenNoTerminalAndNoEnv)
+{
+    ColumnsEnvGuard guard;
+    unsetenv("COLUMNS");
+    EXPECT_EQ(resolve_terminal_width(-1, 80), 80U);
+}
+
+TEST(TerminalWidthTests, InvalidColumnsFallsBack)
+{
+    ColumnsEnvGuard guard;
+    setenv("COLUMNS", "not-a-number", 1);
+    EXPECT_EQ(resolve_terminal_width(-1, 100), 100U);
+}
+
+TEST(TerminalWidthTests, NonPositiveColumnsFallsBack)
+{
+    ColumnsEnvGuard guard;
+    setenv("COLUMNS", "0", 1);
+    EXPECT_EQ(resolve_terminal_width(-1, 77), 77U);
+}
+
+TEST(TerminalWidthTests, TrailingJunkColumnsFallsBack)
+{
+    ColumnsEnvGuard guard;
+    setenv("COLUMNS", "80x", 1);
+    EXPECT_EQ(resolve_terminal_width(-1, 42), 42U);
+}

--- a/porytiles/tests/unit/utilities/text/text_wrap_test.cpp
+++ b/porytiles/tests/unit/utilities/text/text_wrap_test.cpp
@@ -1,0 +1,83 @@
+#include "gtest/gtest.h"
+
+#include <string>
+#include <vector>
+
+#include "porytiles/utilities/text/text_wrap.hpp"
+
+using namespace porytiles;
+
+namespace {
+
+const std::string bold = "\033[1m";
+const std::string reset = "\033[0m";
+
+} // namespace
+
+TEST(TextWrapTests, WidthZeroReturnsInputUnchanged)
+{
+    const std::string input = "this is a fairly long line that would otherwise wrap";
+    EXPECT_EQ(wrap_ansi_line(input, 0), (std::vector<std::string>{input}));
+}
+
+TEST(TextWrapTests, ShortLineIsNotWrapped)
+{
+    EXPECT_EQ(wrap_ansi_line("short", 40), (std::vector<std::string>{"short"}));
+}
+
+TEST(TextWrapTests, EmptyLineStaysEmpty)
+{
+    EXPECT_EQ(wrap_ansi_line("", 40), (std::vector<std::string>{""}));
+}
+
+TEST(TextWrapTests, WrapsAtSpaceBoundaries)
+{
+    EXPECT_EQ(wrap_ansi_line("the quick brown fox", 9), (std::vector<std::string>{"the quick", "brown fox"}));
+}
+
+TEST(TextWrapTests, BreakConsumesTheSpace)
+{
+    // No wrapped line should start or end with the break space.
+    const auto lines = wrap_ansi_line("hello world", 5);
+    ASSERT_EQ(lines.size(), 2);
+    EXPECT_EQ(lines[0], "hello");
+    EXPECT_EQ(lines[1], "world");
+}
+
+TEST(TextWrapTests, MovesOversizedWordToNextLine)
+{
+    EXPECT_EQ(wrap_ansi_line("hello wor", 8), (std::vector<std::string>{"hello", "wor"}));
+}
+
+TEST(TextWrapTests, HardBreaksWordLongerThanWidth)
+{
+    EXPECT_EQ(wrap_ansi_line("abcdefghij", 4), (std::vector<std::string>{"abcd", "efgh", "ij"}));
+}
+
+TEST(TextWrapTests, AnsiEscapesDoNotCountTowardWidth)
+{
+    // Visible text is "hello" (5 cols), which fits in width 5 despite the surrounding escape bytes.
+    const std::string styled = bold + "hello" + reset;
+    EXPECT_EQ(wrap_ansi_line(styled, 5), (std::vector<std::string>{styled}));
+}
+
+TEST(TextWrapTests, StyleCarriesAcrossWrapBoundary)
+{
+    // A bold span "hello world" wrapped at 5 should close bold on the first line and re-open it on the second.
+    const std::string styled = bold + "hello world" + reset;
+    const auto lines = wrap_ansi_line(styled, 5);
+    ASSERT_EQ(lines.size(), 2);
+    EXPECT_EQ(lines[0], bold + "hello" + reset);
+    EXPECT_EQ(lines[1], bold + "world" + reset);
+}
+
+TEST(TextWrapTests, DoesNotSplitMultibyteCodepoint)
+{
+    // "│" is U+2502, a 3-byte UTF-8 sequence counted as a single visible column.
+    const std::string box = "│";
+    const std::string input = box + box + box + box;
+    const auto lines = wrap_ansi_line(input, 2);
+    ASSERT_EQ(lines.size(), 2);
+    EXPECT_EQ(lines[0], box + box);
+    EXPECT_EQ(lines[1], box + box);
+}

--- a/porytiles/tools/driver/command.hpp
+++ b/porytiles/tools/driver/command.hpp
@@ -47,9 +47,13 @@ class Command {
         return *app_;
     }
 
-  protected:
+  private:
+    /// @brief The command's entry point, invoked through the CLI11 callback registered by the constructor.
+    ///
+    /// @details
+    /// Deliberately private, here and in the overrides: Run() assumes CLI11 parsing already populated the command's
+    /// option storage, so nothing outside the parse flow should be able to call it.
     virtual void Run() = 0;
 
-  private:
     CLI::App *app_;
 };

--- a/porytiles/tools/driver/command_compile_tileset.hpp
+++ b/porytiles/tools/driver/command_compile_tileset.hpp
@@ -26,6 +26,7 @@ class CompileTilesetCommand final : public Command {
         porytiles::register_config_options(cmd, cli_storage_);
     }
 
+  private:
     void Run() override
     {
         using namespace porytiles;
@@ -81,7 +82,6 @@ class CompileTilesetCommand final : public Command {
         }
     }
 
-  private:
     static constexpr auto kCommandName = "compile-tileset";
     static constexpr auto kCommandDesc =
         "Compile a tileset -- update the Porymap assets to match the Porytiles assets.";

--- a/porytiles/tools/driver/command_completion.hpp
+++ b/porytiles/tools/driver/command_completion.hpp
@@ -30,6 +30,7 @@ class CompletionCommand final : public Command {
         cmd.add_option("<shell>", shell_, "Shell type: bash, zsh, or fish")->required();
     }
 
+  private:
     void Run() override
     {
         if (shell_ == "bash") {
@@ -48,7 +49,6 @@ class CompletionCommand final : public Command {
         }
     }
 
-  private:
     static constexpr auto kCommandName = "completion";
     static constexpr auto kCommandDesc = "Generate shell completion scripts.";
     static constexpr auto kCommandGroup = "UTILITIES";

--- a/porytiles/tools/driver/command_create_tileset.hpp
+++ b/porytiles/tools/driver/command_create_tileset.hpp
@@ -27,6 +27,7 @@ class CreateTilesetCommand final : public Command {
         porytiles::register_config_options(cmd, cli_storage_);
     }
 
+  private:
     void Run() override
     {
         using namespace porytiles;
@@ -83,7 +84,6 @@ class CreateTilesetCommand final : public Command {
         }
     }
 
-  private:
     static constexpr auto kCommandName = "create-tileset";
     static constexpr auto kCommandDesc = "Create a new Porytiles-managed tileset from scratch.";
     static constexpr auto kCommandGroup = "COMMANDS";

--- a/porytiles/tools/driver/command_decompile_tileset.hpp
+++ b/porytiles/tools/driver/command_decompile_tileset.hpp
@@ -26,6 +26,7 @@ class DecompileTilesetCommand final : public Command {
         porytiles::register_config_options(cmd, cli_storage_);
     }
 
+  private:
     void Run() override
     {
         using namespace porytiles;
@@ -56,7 +57,6 @@ class DecompileTilesetCommand final : public Command {
         }
     }
 
-  private:
     static constexpr auto kCommandName = "decompile-tileset";
     static constexpr auto kCommandDesc =
         "Decompile a tileset -- update the Porytiles assets to match the Porymap assets.";

--- a/porytiles/tools/driver/command_dump_tileset_config.hpp
+++ b/porytiles/tools/driver/command_dump_tileset_config.hpp
@@ -30,6 +30,7 @@ class DumpTilesetConfigCommand final : public Command {
         porytiles::register_config_options(cmd, cli_storage_);
     }
 
+  private:
     void Run() override
     {
         using namespace porytiles;
@@ -106,7 +107,6 @@ class DumpTilesetConfigCommand final : public Command {
         out << "\n";
     }
 
-  private:
     static constexpr auto kCommandName = "dump-tileset-config";
     static constexpr auto kCommandDesc = "Dump the full configuration provenance chain for a tileset.";
     static constexpr auto kCommandGroup = "UTILITIES";

--- a/porytiles/tools/driver/command_import_tileset.hpp
+++ b/porytiles/tools/driver/command_import_tileset.hpp
@@ -26,6 +26,7 @@ class ImportTilesetCommand final : public Command {
         porytiles::register_config_options(cmd, cli_storage_);
     }
 
+  private:
     void Run() override
     {
         using namespace porytiles;
@@ -69,7 +70,6 @@ class ImportTilesetCommand final : public Command {
         }
     }
 
-  private:
     static constexpr auto kCommandName = "import-tileset";
     static constexpr auto kCommandDesc = "Import a pre-existing tileset into Porytiles.";
     static constexpr auto kCommandGroup = "COMMANDS";

--- a/porytiles/tools/driver/command_list_tilesets.hpp
+++ b/porytiles/tools/driver/command_list_tilesets.hpp
@@ -43,6 +43,7 @@ class ListTilesetsCommand final : public Command {
         cmd.add_option("--prefix", prefix_, "Only show tilesets starting with this prefix")->default_val("");
     }
 
+  private:
     void Run() override
     {
         using namespace porytiles;
@@ -93,7 +94,6 @@ class ListTilesetsCommand final : public Command {
         }
     }
 
-  private:
     static constexpr auto kCommandName = "list-tilesets";
     static constexpr auto kCommandDesc = "List tilesets in the project.";
     static constexpr auto kCommandGroup = "UTILITIES";

--- a/porytiles/tools/driver/tileset_command_setup.hpp
+++ b/porytiles/tools/driver/tileset_command_setup.hpp
@@ -47,6 +47,7 @@
 #include "porytiles/infra/services/tileset_attr_schema_cache.hpp"
 #include "porytiles/infra/services/tileset_attr_schema_resolver.hpp"
 #include "porytiles/utilities/result/chainable_result.hpp"
+#include "porytiles/utilities/text/terminal_width.hpp"
 #include "porytiles/xcut/config/config_scope_type.hpp"
 #include "porytiles/xcut/di/components.hpp"
 #include "porytiles/xcut/diagnostics/diagnostic_tag_filter.hpp"
@@ -71,7 +72,8 @@ class TilesetCommandEnv {
   public:
     TilesetCommandEnv(std::filesystem::path root, const std::string &tileset_name, const CliOptionStorage &cli_storage)
         : project_root{std::move(root)}, injector{di::get_formatter_component, !isatty(STDERR_FILENO)},
-          text_formatter{injector.get<TextFormatter *>()}, stderr_diag{text_formatter},
+          text_formatter{injector.get<TextFormatter *>()},
+          stderr_diag{text_formatter, resolve_terminal_width(STDERR_FILENO)},
           config{text_formatter, make_providers(yaml_provider, project_root, cli_storage, text_formatter, &stderr_diag)}
     {
         // Eagerly validate all YAML config files for unknown keys

--- a/porytiles/tools/driver/tileset_command_setup.hpp
+++ b/porytiles/tools/driver/tileset_command_setup.hpp
@@ -9,6 +9,7 @@
 
 #include "CLI/CLI.hpp"
 #include "fruit/fruit.h"
+#include "gsl/pointers"
 
 #include "porytiles/domain/repos/tileset_repo.hpp"
 #include "porytiles/domain/services/palette_printer.hpp"
@@ -57,24 +58,56 @@
 
 namespace porytiles {
 
-/// @brief The config and diagnostics bootstrap every tileset command runs before doing anything else.
+/// @brief Bootstrap class so every tileset command can share common config and diagnostic setup.
 ///
 /// @details
-/// Owns the formatter injector, the unfiltered stderr diagnostics used during config loading, the layered config
-/// (CLI options over YAML over header defines over defaults), and the filtered diagnostics built from the config's
-/// diagnostic include/exclude patterns. Construction eagerly validates the YAML config files for the tileset scope
-/// and fails the command (fatal diagnostic plus CLI::RuntimeError) on validation errors, exactly like the inline
-/// bootstrap it replaces.
+/// Owns the formatter injector, the unfiltered stderr diagnostics used during config loading, the layered config,
+/// and the filtered diagnostics built from the config's diagnostic include/exclude patterns. Construction eagerly
+/// validates the YAML config files for the tileset scope and fails the command on validation errors.
 ///
-/// Members hold pointers into earlier members, so the env is pinned to its construction site: not copyable, not
-/// movable. Commands construct it once on the stack and keep it alive for the whole run.
+/// Members hold pointers into earlier members, so the class is not copyable and not movable. Commands should construct
+/// it once on the stack.
 class TilesetCommandEnv {
+  private:
+    /// @brief The layered config's provider list bundled with a typed handle to the YamlFileProvider inside it.
+    ///
+    /// @details
+    /// make_provider_chain returns both pieces together so the constructor can hand ownership of the list to config
+    /// while keeping the typed handle it needs for YAML validation. The handle points at the provider owned by the
+    /// list (and, after construction, by config), so it stays valid for the env's whole lifetime.
+    struct ProviderChain {
+        std::vector<std::unique_ptr<ConfigProvider>> providers;
+        gsl::not_null<YamlFileProvider *> yaml_provider;
+    };
+
+    [[nodiscard]] static ProviderChain make_provider_chain(
+        const std::filesystem::path &project_root,
+        const CliOptionStorage &cli_storage,
+        TextFormatter *text_formatter,
+        StderrStyledUserDiagnostics *stderr_diag)
+    {
+        // Layered configuration: CLI options have highest priority.
+        std::vector<std::unique_ptr<ConfigProvider>> providers{};
+        providers.push_back(std::make_unique<CliOptionProvider>(cli_storage));
+        providers.push_back(std::make_unique<YamlFileProvider>(text_formatter, stderr_diag, project_root));
+        // Take the handle from the owning slot so its provenance is the list itself, not a moved-from local.
+        auto *yaml_provider = static_cast<YamlFileProvider *>(providers.back().get());
+        providers.push_back(
+            std::make_unique<HeaderDefineProvider>(
+                project_root, std::filesystem::path{"include/fieldmap.h"}, text_formatter));
+        providers.push_back(
+            std::make_unique<MetatileAttributeConfigProvider>(project_root, text_formatter, stderr_diag));
+        providers.push_back(std::make_unique<DefaultProvider>());
+        return {std::move(providers), yaml_provider};
+    }
+
   public:
     TilesetCommandEnv(std::filesystem::path root, const std::string &tileset_name, const CliOptionStorage &cli_storage)
         : project_root{std::move(root)}, injector{di::get_formatter_component, !isatty(STDERR_FILENO)},
           text_formatter{injector.get<TextFormatter *>()},
           stderr_diag{text_formatter, resolve_terminal_width(STDERR_FILENO)},
-          config{text_formatter, make_providers(yaml_provider, project_root, cli_storage, text_formatter, &stderr_diag)}
+          provider_chain{make_provider_chain(project_root, cli_storage, text_formatter, &stderr_diag)},
+          yaml_provider{provider_chain.yaml_provider}, config{text_formatter, std::move(provider_chain.providers)}
     {
         // Eagerly validate all YAML config files for unknown keys
         if (yaml_provider->preload_and_validate(ConfigScopeType::tileset, tileset_name)) {
@@ -117,33 +150,17 @@ class TilesetCommandEnv {
     fruit::Injector<TextFormatter> injector;
     TextFormatter *text_formatter;
     StderrStyledUserDiagnostics stderr_diag;
-    // Set by make_providers during config's initialization; declared before config so the assignment sticks.
-    YamlFileProvider *yaml_provider = nullptr;
-    LazyLayeredConfig config;
-    std::unique_ptr<FilteredUserDiagnostics> diag;
 
   private:
-    [[nodiscard]] static std::vector<std::unique_ptr<ConfigProvider>> make_providers(
-        YamlFileProvider *&yaml_provider_out,
-        const std::filesystem::path &project_root,
-        const CliOptionStorage &cli_storage,
-        TextFormatter *text_formatter,
-        StderrStyledUserDiagnostics *stderr_diag)
-    {
-        // Layered configuration: CLI options have highest priority.
-        std::vector<std::unique_ptr<ConfigProvider>> providers{};
-        providers.push_back(std::make_unique<CliOptionProvider>(cli_storage));
-        auto yaml_provider = std::make_unique<YamlFileProvider>(text_formatter, stderr_diag, project_root);
-        yaml_provider_out = yaml_provider.get();
-        providers.push_back(std::move(yaml_provider));
-        providers.push_back(
-            std::make_unique<HeaderDefineProvider>(
-                project_root, std::filesystem::path{"include/fieldmap.h"}, text_formatter));
-        providers.push_back(
-            std::make_unique<MetatileAttributeConfigProvider>(project_root, text_formatter, stderr_diag));
-        providers.push_back(std::make_unique<DefaultProvider>());
-        return providers;
-    }
+    // Bridges make_provider_chain's single return value across two member initializers: yaml_provider copies the
+    // handle, config takes ownership of the vector. After construction the providers vector is moved-from and empty.
+    ProviderChain provider_chain;
+
+  public:
+    // Typed handle to the YamlFileProvider owned by config's provider list, needed for eager YAML validation.
+    gsl::not_null<YamlFileProvider *> yaml_provider;
+    LazyLayeredConfig config;
+    std::unique_ptr<FilteredUserDiagnostics> diag;
 };
 
 /// @brief The schema-driven service graph shared by the compile, create, import, and decompile commands.


### PR DESCRIPTION
Closes #339

Added auto-wrap support for all diagnostic messages to simplify internal callsites. On the user side, diagnostics now dynamically wrap based on terminal width (as reported by ioctl). This can be overridden via the standard `COLUMNS` environment var.